### PR TITLE
Make requests succeed even if body write errored

### DIFF
--- a/changelog/@unreleased/pr-13.v2.yml
+++ b/changelog/@unreleased/pr-13.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Requests are now always considered to have succeeded if the server
+    returns an successful response, even if the streaming body write failed.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/13

--- a/conjure-runtime-config/Cargo.toml
+++ b/conjure-runtime-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime-config"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -37,7 +37,7 @@ tokio = { version = "0.2", features = ["io-util", "rt-threaded", "time"] }
 url = "2.0"
 zipkin = "0.4"
 
-conjure-runtime-config = { version = "0.1.1", path = "../conjure-runtime-config" }
+conjure-runtime-config = { version = "0.1.2", path = "../conjure-runtime-config" }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/conjure-runtime/src/test.rs
+++ b/conjure-runtime/src/test.rs
@@ -627,13 +627,7 @@ async fn body_write_ends_after_error() {
         |_| async { Ok(Response::new(hyper::Body::empty())) },
         |client| {
             async move {
-                client
-                    .post("/")
-                    .body(InfiniteBody)
-                    .send()
-                    .await
-                    .err()
-                    .unwrap();
+                client.post("/").body(InfiniteBody).send().await.unwrap();
             }
         },
     )


### PR DESCRIPTION
## Before this PR
If the streaming body write for a request failed but the server returned a successful response, we would treat the entire request as failed.

## After this PR
==COMMIT_MSG==
Requests are now always considered to have succeeded if the server returns an successful response, even if the streaming body write failed.
==COMMIT_MSG==

