### PR TITLE
Drop mesh proxy support

### DIFF
--- a/changelog/@unreleased/pr-50.v2.yml
+++ b/changelog/@unreleased/pr-50.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Removed support for mesh proxies.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/50

--- a/conjure-runtime-config/src/lib.rs
+++ b/conjure-runtime-config/src/lib.rs
@@ -390,8 +390,6 @@ pub enum ProxyConfig {
     Direct,
     /// An HTTP proxy.
     Http(HttpProxyConfig),
-    /// A mesh proxy.
-    Mesh(MeshProxyConfig),
 }
 
 impl Default for ProxyConfig {
@@ -554,65 +552,6 @@ impl BasicCredentials {
     /// Returns the password.
     pub fn password(&self) -> &str {
         &self.password
-    }
-}
-
-/// Configuration for a mesh proxy.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct MeshProxyConfig {
-    host_and_port: HostAndPort,
-}
-
-impl MeshProxyConfig {
-    /// Creates a new builder.
-    pub fn builder() -> MeshProxyConfigBuilder {
-        MeshProxyConfigBuilder::default()
-    }
-
-    /// Returns the host and port of the proxy server.
-    pub fn host_and_port(&self) -> &HostAndPort {
-        &self.host_and_port
-    }
-}
-
-/// A builder type for `MeshProxyConfig`s.
-pub struct MeshProxyConfigBuilder {
-    host_and_port: Option<HostAndPort>,
-}
-
-impl Default for MeshProxyConfigBuilder {
-    fn default() -> MeshProxyConfigBuilder {
-        MeshProxyConfigBuilder {
-            host_and_port: None,
-        }
-    }
-}
-
-impl From<MeshProxyConfig> for MeshProxyConfigBuilder {
-    fn from(config: MeshProxyConfig) -> MeshProxyConfigBuilder {
-        MeshProxyConfigBuilder {
-            host_and_port: Some(config.host_and_port),
-        }
-    }
-}
-
-impl MeshProxyConfigBuilder {
-    /// Sets the host and port.
-    pub fn host_and_port(&mut self, host_and_port: HostAndPort) -> &mut Self {
-        self.host_and_port = Some(host_and_port);
-        self
-    }
-
-    /// Creates a new `MeshProxyBuilder`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `host_and_port` is not set.
-    pub fn build(&self) -> MeshProxyConfig {
-        MeshProxyConfig {
-            host_and_port: self.host_and_port.clone().expect("host_and_port not set"),
-        }
     }
 }
 

--- a/conjure-runtime-config/src/test.rs
+++ b/conjure-runtime-config/src/test.rs
@@ -100,8 +100,7 @@ fn service_overrides() {
                         "ca-file": "/fizz/buzz"
                     },
                     "proxy": {
-                        "type": "mesh",
-                        "host-and-port": "localhost:5678"
+                        "type": "direct"
                     },
                     "connect-timeout": "13 seconds",
                     "request-timeout": "2 minutes"
@@ -130,11 +129,7 @@ fn service_overrides() {
                 .ca_file(Some("/fizz/buzz".into()))
                 .build(),
         )
-        .proxy(ProxyConfig::Mesh(
-            MeshProxyConfig::builder()
-                .host_and_port(HostAndPort::new("localhost", 5678))
-                .build(),
-        ))
+        .proxy(ProxyConfig::Direct)
         .connect_timeout(Duration::from_secs(13))
         .request_timeout(Duration::from_secs(2 * 60))
         .build();

--- a/conjure-runtime/src/service/proxy/mod.rs
+++ b/conjure-runtime/src/service/proxy/mod.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::config::{self, HostAndPort};
+use crate::config;
 pub use crate::service::proxy::connector::{ProxyConnectorLayer, ProxyConnectorService};
 pub use crate::service::proxy::request::{ProxyLayer, ProxyService};
 use conjure_error::Error;
@@ -24,7 +24,6 @@ pub mod request;
 #[derive(Clone)]
 pub enum ProxyConfig {
     Http(HttpProxyConfig),
-    Mesh(MeshProxyConfig),
     Direct,
 }
 
@@ -32,11 +31,6 @@ pub enum ProxyConfig {
 pub struct HttpProxyConfig {
     uri: Uri,
     credentials: Option<HeaderValue>,
-}
-
-#[derive(Clone)]
-pub struct MeshProxyConfig {
-    host_and_port: HostAndPort,
 }
 
 impl ProxyConfig {
@@ -61,9 +55,6 @@ impl ProxyConfig {
 
                 Ok(ProxyConfig::Http(HttpProxyConfig { uri, credentials }))
             }
-            config::ProxyConfig::Mesh(config) => Ok(ProxyConfig::Mesh(MeshProxyConfig {
-                host_and_port: config.host_and_port().clone(),
-            })),
             _ => Err(Error::internal_safe("unknown proxy type")),
         }
     }

--- a/conjure-runtime/src/service/proxy/request.rs
+++ b/conjure-runtime/src/service/proxy/request.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::service::proxy::ProxyConfig;
-use http::header::{HOST, PROXY_AUTHORIZATION};
+use http::header::PROXY_AUTHORIZATION;
 use http::uri::Scheme;
-use http::{HeaderValue, Request, Uri};
-use std::convert::TryFrom;
+use http::Request;
 use std::task::{Context, Poll};
 use tower::layer::Layer;
 use tower::Service;
-use url::Url;
 
 /// A layer which adjusts an HTTP request as necessary to respect proxy settings.
 ///
@@ -27,9 +25,6 @@ use url::Url;
 ///
 /// For http requests over an HTTP proxy, we inject the `Proxy-Authorization` header if necessary. For https requests
 /// authorization is handled in the `CONNECT` request made by the `ProxyConnectorLayer`.
-///
-/// For requests over a mesh proxy, we replace the host and port of the request URI with that of the proxy server and
-/// put the target host/port in the `Host` header.
 pub struct ProxyLayer {
     config: ProxyConfig,
 }
@@ -80,21 +75,6 @@ where
                     }
                 }
             }
-            ProxyConfig::Mesh(config) => {
-                let mut url = Url::parse(&req.uri().to_string()).unwrap();
-
-                let host = url.host_str().unwrap();
-                let host = match url.port() {
-                    Some(port) => format!("{}:{}", host, port),
-                    None => host.to_string(),
-                };
-                let host = HeaderValue::try_from(host).unwrap();
-                req.headers_mut().insert(HOST, host);
-                url.set_host(Some(config.host_and_port.host())).unwrap();
-                url.set_port(Some(config.host_and_port.port())).unwrap();
-
-                *req.uri_mut() = Uri::try_from(url.into_string()).unwrap();
-            }
             ProxyConfig::Direct => {}
         }
 
@@ -105,8 +85,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::config::{self, BasicCredentials, HostAndPort, HttpProxyConfig, MeshProxyConfig};
-    use http::HeaderMap;
+    use crate::config::{self, BasicCredentials, HostAndPort, HttpProxyConfig};
+    use http::{HeaderMap, HeaderValue};
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -160,31 +140,6 @@ mod test {
         assert_eq!(out.uri(), "https://foobar.com/fizz/buzz");
 
         let headers = HeaderMap::new();
-        assert_eq!(*out.headers(), headers);
-    }
-
-    #[tokio::test]
-    async fn mesh_proxied() {
-        let config = ProxyConfig::from_config(&config::ProxyConfig::Mesh(
-            MeshProxyConfig::builder()
-                .host_and_port(HostAndPort::new("proxy", 1234))
-                .build(),
-        ))
-        .unwrap();
-
-        let service =
-            ProxyLayer::new(&config).layer(tower::service_fn(|req| async { Ok::<_, ()>(req) }));
-
-        let req = Request::builder()
-            .uri("https://foobar.com/fizz/buzz")
-            .body(())
-            .unwrap();
-        let out = service.oneshot(req).await.unwrap();
-
-        assert_eq!(out.uri(), "https://proxy:1234/fizz/buzz");
-
-        let mut headers = HeaderMap::new();
-        headers.insert(HOST, HeaderValue::from_static("foobar.com"));
         assert_eq!(*out.headers(), headers);
     }
 


### PR DESCRIPTION
## Before this PR
We supported an envoy-style mesh proxy, but never used it.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Removed support for mesh proxies.
==COMMIT_MSG==

Dialogue has never supported this proxy type, and our new mesh logic is going to be handled differently: https://github.com/palantir/dialogue/pull/1048

