### PR TITLE
Define our own Service and Layer traits

### DIFF
--- a/conjure-runtime/src/blocking/client.rs
+++ b/conjure-runtime/src/blocking/client.rs
@@ -20,8 +20,13 @@ use http::Method;
 ///
 /// It implements the Conjure `Client` trait, but also offers a "raw" request interface for use with services that don't
 /// provide Conjure service definitions.
-#[derive(Clone)]
 pub struct Client<T = DefaultRawClient>(pub(crate) crate::Client<T>);
+
+impl<T> Clone for Client<T> {
+    fn clone(&self) -> Self {
+        Client(self.0.clone())
+    }
+}
 
 impl Client {
     /// Returns a new `Builder` for clients.

--- a/conjure-runtime/src/blocking/conjure.rs
+++ b/conjure-runtime/src/blocking/conjure.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::blocking::{Body, BodyWriter, Client, Response, ResponseBody};
-use crate::raw;
+use crate::raw::{self, Service};
 use crate::{APPLICATION_JSON, APPLICATION_OCTET_STREAM};
 use bytes::Bytes;
 use conjure_error::Error;
@@ -24,15 +24,10 @@ use hyper::{HeaderMap, Method, StatusCode};
 use serde::Serialize;
 use std::error;
 use std::io::Read;
-use tower::Service;
 
 impl<T, B> Client<T>
 where
-    T: Service<http::Request<raw::RawBody>, Response = http::Response<B>>
-        + Clone
-        + 'static
-        + Sync
-        + Send,
+    T: Service<http::Request<raw::RawBody>, Response = http::Response<B>> + 'static + Sync + Send,
     T::Error: Into<Box<dyn error::Error + Sync + Send>>,
     T::Future: Send,
     B: http_body::Body<Data = Bytes> + 'static + Send,
@@ -83,11 +78,7 @@ where
 
 impl<T, B> conjure_http::client::Client for Client<T>
 where
-    T: Service<http::Request<raw::RawBody>, Response = http::Response<B>>
-        + Clone
-        + 'static
-        + Sync
-        + Send,
+    T: Service<http::Request<raw::RawBody>, Response = http::Response<B>> + 'static + Sync + Send,
     T::Error: Into<Box<dyn error::Error + Sync + Send>>,
     T::Future: Send,
     B: http_body::Body<Data = Bytes> + 'static + Send,

--- a/conjure-runtime/src/blocking/request.rs
+++ b/conjure-runtime/src/blocking/request.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::blocking::{runtime, Body, BodyShim, BodyStreamer, Client, Response};
+use crate::raw::Service;
 use crate::raw::{DefaultRawClient, RawBody};
 use crate::Request;
 use bytes::Bytes;
@@ -25,7 +26,6 @@ use std::error;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tower::Service;
 use zipkin::TraceContext;
 
 /// A builder for a blocking HTTP request.
@@ -119,11 +119,7 @@ impl<'a, T> RequestBuilder<'a, T> {
 
 impl<'a, T, B> RequestBuilder<'a, T>
 where
-    T: Service<http::Request<RawBody>, Response = http::Response<B>>
-        + Clone
-        + 'static
-        + Sync
-        + Send,
+    T: Service<http::Request<RawBody>, Response = http::Response<B>> + 'static + Sync + Send,
     T::Error: Into<Box<dyn error::Error + Sync + Send>>,
     T::Future: Send,
     B: http_body::Body<Data = Bytes> + 'static + Send,

--- a/conjure-runtime/src/conjure.rs
+++ b/conjure-runtime/src/conjure.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::raw;
+use crate::raw::{self, Service};
 use crate::{
     Body, BodyWriter, Client, RequestBuilder, Response, ResponseBody, APPLICATION_JSON,
     APPLICATION_OCTET_STREAM,
@@ -32,11 +32,10 @@ use std::error;
 use std::future::Future;
 use std::pin::Pin;
 use tokio::io::AsyncReadExt;
-use tower::Service;
 
 impl<T, B> Client<T>
 where
-    T: Service<http::Request<raw::RawBody>, Response = http::Response<B>> + Clone + 'static + Send,
+    T: Service<http::Request<raw::RawBody>, Response = http::Response<B>> + 'static + Sync + Send,
     T::Error: Into<Box<dyn error::Error + Sync + Send>>,
     T::Future: Send,
     B: http_body::Body<Data = Bytes> + Send,
@@ -80,11 +79,7 @@ where
 
 impl<T, B> AsyncClient for Client<T>
 where
-    T: Service<http::Request<raw::RawBody>, Response = http::Response<B>>
-        + Clone
-        + 'static
-        + Sync
-        + Send,
+    T: Service<http::Request<raw::RawBody>, Response = http::Response<B>> + 'static + Sync + Send,
     T::Error: Into<Box<dyn error::Error + Sync + Send>>,
     T::Future: Send,
     B: http_body::Body<Data = Bytes> + Sync + Send,

--- a/conjure-runtime/src/raw/mod.rs
+++ b/conjure-runtime/src/raw/mod.rs
@@ -34,9 +34,27 @@ pub use crate::raw::body::*;
 pub use crate::raw::default::*;
 use crate::Builder;
 use conjure_error::Error;
+use std::future::Future;
 
 mod body;
 mod default;
+
+/// An asynchronous function from request to response.
+///
+/// This trait is based on the `tower::Service` trait, but differs in two ways. It does not have a `poll_ready` method
+/// as our client-side backpressure depends on the request, and the `call` method takes `&self` rather than `&mut self`
+/// as our client is designed to be used through a shared reference.
+pub trait Service<R> {
+    /// The response type returned by the service.
+    type Response;
+    /// The error type returned by the service.
+    type Error;
+    /// The future type returned by the service.
+    type Future: Future<Output = Result<Self::Response, Self::Error>>;
+
+    /// Asynchronously perform the request.
+    fn call(&self, req: R) -> Self::Future;
+}
 
 /// A factory of raw HTTP clients.
 pub trait BuildRawClient {

--- a/conjure-runtime/src/request.rs
+++ b/conjure-runtime/src/request.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::raw::Service;
 use crate::raw::{DefaultRawClient, RawBody};
 use crate::{Body, Client, ResetTrackingBody, Response};
 use bytes::Bytes;
@@ -24,7 +25,6 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::error;
 use std::pin::Pin;
-use tower::Service;
 
 static DEFAULT_ACCEPT: Lazy<HeaderValue> = Lazy::new(|| HeaderValue::from_static("*/*"));
 
@@ -115,7 +115,7 @@ impl<'a, T> RequestBuilder<'a, T> {
 
 impl<'a, T, B> RequestBuilder<'a, T>
 where
-    T: Service<http::Request<RawBody>, Response = http::Response<B>> + Clone + 'static + Send,
+    T: Service<http::Request<RawBody>, Response = http::Response<B>> + 'static + Sync + Send,
     T::Error: Into<Box<dyn error::Error + Sync + Send>>,
     T::Future: Send,
     B: http_body::Body<Data = Bytes> + Send,

--- a/conjure-runtime/src/service/mod.rs
+++ b/conjure-runtime/src/service/mod.rs
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::raw::Service;
+use std::future::Future;
+
 pub mod gzip;
 pub mod http_error;
 pub mod map_error;
@@ -25,3 +28,103 @@ pub mod timeout;
 pub mod tls_metrics;
 pub mod trace_propagation;
 pub mod user_agent;
+
+/// A function from one service type to another.
+///
+/// This trait is based off of the `tower::layer::Layer` trait, but differs in one way. The `layer` method takes `self`
+/// rather than `&self`. We build a single service when constructing the client and keep that around, so there's no need
+/// to allow for layers to be reused. The `Layer` trait exists solely to help make the initialization of the client's
+/// service more orderly and maintainable.
+pub trait Layer<S> {
+    type Service;
+
+    fn layer(self, inner: S) -> Self::Service;
+}
+
+/// A layer which does nothing.
+pub struct Identity;
+
+impl<S> Layer<S> for Identity {
+    type Service = S;
+
+    fn layer(self, inner: S) -> Self::Service {
+        inner
+    }
+}
+
+/// A layer which applies two other layers in order.
+///
+/// # Note
+///
+/// The parameter order here is reversed when compared to `tower::layer::Stack`, as it makes the type definition macro
+/// in the `client` module cleaner.
+pub struct Stack<T, U> {
+    inner: U,
+    outer: T,
+}
+
+impl<T, U, S> Layer<S> for Stack<T, U>
+where
+    T: Layer<U::Service>,
+    U: Layer<S>,
+{
+    type Service = T::Service;
+
+    fn layer(self, inner: S) -> Self::Service {
+        let inner = self.inner.layer(inner);
+        self.outer.layer(inner)
+    }
+}
+
+/// A builder type for `Service`s.
+///
+/// The builder allows you to "linearize" the layers composed to build a service in a builder-style API rather than
+/// having to make repeated nested calls.
+pub struct ServiceBuilder<L> {
+    layer: L,
+}
+
+impl ServiceBuilder<Identity> {
+    pub fn new() -> Self {
+        ServiceBuilder { layer: Identity }
+    }
+}
+
+impl<L> ServiceBuilder<L> {
+    pub fn layer<T>(self, layer: T) -> ServiceBuilder<Stack<L, T>> {
+        ServiceBuilder {
+            layer: Stack {
+                inner: layer,
+                outer: self.layer,
+            },
+        }
+    }
+
+    pub fn service<S>(self, service: S) -> L::Service
+    where
+        L: Layer<S>,
+    {
+        self.layer.layer(service)
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn service_fn<T>(f: T) -> ServiceFn<T> {
+    ServiceFn(f)
+}
+
+pub struct ServiceFn<T>(T);
+
+impl<T, R, F, S, E> Service<R> for ServiceFn<T>
+where
+    T: Fn(R) -> F,
+    F: Future<Output = Result<S, E>>,
+{
+    type Response = S;
+    type Error = E;
+    type Future = F;
+
+    fn call(&self, req: R) -> Self::Future {
+        (self.0)(req)
+    }
+}

--- a/conjure-runtime/src/service/node/metrics.rs
+++ b/conjure-runtime/src/service/node/metrics.rs
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::raw::Service;
 use crate::service::node::Node;
+use crate::service::Layer;
 use futures::ready;
 use http::{Request, Response};
 use pin_project::pin_project;
@@ -20,8 +22,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
-use tower::layer::Layer;
-use tower::Service;
 
 /// A layer which updates the host metrics for the node stored in the request's extensions map.
 pub struct NodeMetricsLayer;
@@ -29,7 +29,7 @@ pub struct NodeMetricsLayer;
 impl<S> Layer<S> for NodeMetricsLayer {
     type Service = NodeMetricsService<S>;
 
-    fn layer(&self, inner: S) -> NodeMetricsService<S> {
+    fn layer(self, inner: S) -> NodeMetricsService<S> {
         NodeMetricsService { inner }
     }
 }
@@ -46,11 +46,7 @@ where
     type Response = S::Response;
     type Future = NodeMetricsFuture<S::Future>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, req: Request<B1>) -> Self::Future {
+    fn call(&self, req: Request<B1>) -> Self::Future {
         let node = req
             .extensions()
             .get::<Arc<Node>>()

--- a/conjure-runtime/src/service/node/selector/empty.rs
+++ b/conjure-runtime/src/service/node/selector/empty.rs
@@ -11,14 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::raw::Service;
+use crate::service::Layer;
 use conjure_error::Error;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tower::layer::Layer;
-use tower::Service;
 
 /// A node selector that always returns an error.
 pub struct EmptyNodeSelectorLayer {
@@ -36,9 +36,9 @@ impl EmptyNodeSelectorLayer {
 impl<S> Layer<S> for EmptyNodeSelectorLayer {
     type Service = EmptyNodeSelectorService<S>;
 
-    fn layer(&self, _: S) -> Self::Service {
+    fn layer(self, _: S) -> Self::Service {
         EmptyNodeSelectorService {
-            service: self.service.clone(),
+            service: self.service,
             _p: PhantomData,
         }
     }
@@ -57,11 +57,7 @@ where
     type Error = Error;
     type Future = EmptyNodeSelectorFuture<S::Future>;
 
-    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, _: R) -> Self::Future {
+    fn call(&self, _: R) -> Self::Future {
         EmptyNodeSelectorFuture {
             service: self.service.clone(),
             _p: PhantomData,

--- a/conjure-runtime/src/service/response.rs
+++ b/conjure-runtime/src/service/response.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::client::BaseBody;
+use crate::raw::Service;
+use crate::service::Layer;
 use crate::Response;
 use bytes::Bytes;
 use http_body::Body;
@@ -20,8 +22,6 @@ use std::error;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tower::layer::Layer;
-use tower::Service;
 
 /// A layer which converts a hyper `Response` to a conjure-runtime `Response`.
 pub struct ResponseLayer;
@@ -29,7 +29,7 @@ pub struct ResponseLayer;
 impl<S> Layer<S> for ResponseLayer {
     type Service = ResponseService<S>;
 
-    fn layer(&self, inner: S) -> ResponseService<S> {
+    fn layer(self, inner: S) -> ResponseService<S> {
         ResponseService { inner }
     }
 }
@@ -48,11 +48,7 @@ where
     type Error = S::Error;
     type Future = ResponseFuture<S::Future>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, req: R) -> Self::Future {
+    fn call(&self, req: R) -> Self::Future {
         ResponseFuture {
             future: self.inner.call(req),
         }


### PR DESCRIPTION
Our `Service` removes `poll_ready` as we don't use it, and changes `call` to take `&self` rather than `&mut self`. Our `Layer` changes `layer` to take `self` instead of `&self`.

There shouldn't be any behavior change here, but the retry layer in particular becomes way less weird. This will also unblock client-side QoS support.