### PR TITLE
Replace request_timeout with read/write_timeout

### DIFF
--- a/changelog/@unreleased/pr-63.v2.yml
+++ b/changelog/@unreleased/pr-63.v2.yml
@@ -1,0 +1,6 @@
+type: break
+break:
+  description: The request timeout has been replaced by socket-level read and write
+    timeouts.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/63

--- a/conjure-runtime-config/src/lib.rs
+++ b/conjure-runtime-config/src/lib.rs
@@ -57,7 +57,9 @@ pub struct ServicesConfig {
     #[serde(deserialize_with = "de_opt_duration")]
     connect_timeout: Option<Duration>,
     #[serde(deserialize_with = "de_opt_duration")]
-    request_timeout: Option<Duration>,
+    read_timeout: Option<Duration>,
+    #[serde(deserialize_with = "de_opt_duration")]
+    write_timeout: Option<Duration>,
     #[serde(deserialize_with = "de_opt_duration")]
     backoff_slot_size: Option<Duration>,
 }
@@ -84,8 +86,12 @@ impl ServicesConfig {
             service.connect_timeout = self.connect_timeout;
         }
 
-        if service.request_timeout.is_none() {
-            service.request_timeout = self.request_timeout;
+        if service.read_timeout.is_none() {
+            service.read_timeout = self.read_timeout;
+        }
+
+        if service.write_timeout.is_none() {
+            service.write_timeout = self.write_timeout;
         }
 
         if service.backoff_slot_size.is_none() {
@@ -110,9 +116,14 @@ impl ServicesConfig {
         self.connect_timeout
     }
 
-    /// Returns the request timeout.
-    pub fn request_timeout(&self) -> Option<Duration> {
-        self.request_timeout
+    /// Returns the read timeout.
+    pub fn read_timeout(&self) -> Option<Duration> {
+        self.read_timeout
+    }
+
+    /// Returns the write timeout.
+    pub fn write_timeout(&self) -> Option<Duration> {
+        self.write_timeout
     }
 
     /// Returns the backoff slot size.
@@ -161,9 +172,15 @@ impl ServicesConfigBuilder {
         self
     }
 
-    /// Sets the request timeout.
-    pub fn request_timeout(&mut self, request_timeout: Duration) -> &mut Self {
-        self.0.request_timeout = Some(request_timeout);
+    /// Sets the read timeout.
+    pub fn read_timeout(&mut self, read_timeout: Duration) -> &mut Self {
+        self.0.read_timeout = Some(read_timeout);
+        self
+    }
+
+    /// Sets the write timeout.
+    pub fn write_timeout(&mut self, write_timeout: Duration) -> &mut Self {
+        self.0.write_timeout = Some(write_timeout);
         self
     }
 
@@ -189,7 +206,9 @@ pub struct ServiceConfig {
     #[serde(deserialize_with = "de_opt_duration")]
     connect_timeout: Option<Duration>,
     #[serde(deserialize_with = "de_opt_duration")]
-    request_timeout: Option<Duration>,
+    read_timeout: Option<Duration>,
+    #[serde(deserialize_with = "de_opt_duration")]
+    write_timeout: Option<Duration>,
     #[serde(deserialize_with = "de_opt_duration")]
     backoff_slot_size: Option<Duration>,
     max_num_retries: Option<u32>,
@@ -221,9 +240,14 @@ impl ServiceConfig {
         self.connect_timeout
     }
 
-    /// Returns the request timeout.
-    pub fn request_timeout(&self) -> Option<Duration> {
-        self.request_timeout
+    /// Returns the read timeout.
+    pub fn read_timeout(&self) -> Option<Duration> {
+        self.read_timeout
+    }
+
+    /// Returns the write timeout.
+    pub fn write_timeout(&self) -> Option<Duration> {
+        self.write_timeout
     }
 
     /// Returns the backoff slot size.
@@ -278,9 +302,15 @@ impl ServiceConfigBuilder {
         self
     }
 
-    /// Sets the request timeout.
-    pub fn request_timeout(&mut self, request_timeout: Duration) -> &mut Self {
-        self.0.request_timeout = Some(request_timeout);
+    /// Sets the read timeout.
+    pub fn read_timeout(&mut self, read_timeout: Duration) -> &mut Self {
+        self.0.read_timeout = Some(read_timeout);
+        self
+    }
+
+    /// Sets the write timeout.
+    pub fn write_timeout(&mut self, write_timeout: Duration) -> &mut Self {
+        self.0.write_timeout = Some(write_timeout);
         self
     }
 

--- a/conjure-runtime-config/src/test.rs
+++ b/conjure-runtime-config/src/test.rs
@@ -64,7 +64,7 @@ fn root_defaults() {
                 }
             },
             "connect-timeout": "11 seconds",
-            "request-timeout": "3 minutes"
+            "read-timeout": "3 minutes"
         }
     "#;
     let config = serde_json::from_str::<ServicesConfig>(config).unwrap();
@@ -82,7 +82,7 @@ fn root_defaults() {
                 .build(),
         ))
         .connect_timeout(Duration::from_secs(11))
-        .request_timeout(Duration::from_secs(3 * 60))
+        .read_timeout(Duration::from_secs(3 * 60))
         .build();
     assert_eq!(config.merged_service("foo"), Some(expected));
 }
@@ -103,7 +103,7 @@ fn service_overrides() {
                         "type": "direct"
                     },
                     "connect-timeout": "13 seconds",
-                    "request-timeout": "2 minutes"
+                    "read-timeout": "2 minutes"
                 }
             },
             "security": {
@@ -118,7 +118,7 @@ fn service_overrides() {
                 }
             },
             "connect-timeout": "11 seconds",
-            "request-timeout": "3 minutes"
+            "read-timeout": "3 minutes"
         }
     "#;
     let config = serde_json::from_str::<ServicesConfig>(config).unwrap();
@@ -131,7 +131,7 @@ fn service_overrides() {
         )
         .proxy(ProxyConfig::Direct)
         .connect_timeout(Duration::from_secs(13))
-        .request_timeout(Duration::from_secs(2 * 60))
+        .read_timeout(Duration::from_secs(2 * 60))
         .build();
     assert_eq!(config.merged_service("foo"), Some(expected));
 }

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -37,6 +37,7 @@ serde = "1.0"
 witchcraft-log = "0.3"
 witchcraft-metrics = "0.2"
 tokio = { version = "0.2", features = ["io-util", "rt-threaded", "time"] }
+tokio-io-timeout = "0.4"
 tower = "0.3"
 url = "2.0"
 zipkin = "0.4"

--- a/conjure-runtime/src/builder.rs
+++ b/conjure-runtime/src/builder.rs
@@ -31,7 +31,8 @@ pub struct Builder<T = DefaultRawClientBuilder> {
     security: SecurityConfig,
     proxy: ProxyConfig,
     connect_timeout: Duration,
-    request_timeout: Duration,
+    read_timeout: Duration,
+    write_timeout: Duration,
     backoff_slot_size: Duration,
     max_num_retries: u32,
     server_qos: ServerQos,
@@ -60,7 +61,8 @@ impl Builder {
             security: SecurityConfig::builder().build(),
             proxy: ProxyConfig::Direct,
             connect_timeout: Duration::from_secs(10),
-            request_timeout: Duration::from_secs(5 * 60),
+            read_timeout: Duration::from_secs(5 * 60),
+            write_timeout: Duration::from_secs(5 * 60),
             backoff_slot_size: Duration::from_millis(250),
             max_num_retries: 4,
             server_qos: ServerQos::AutomaticRetry,
@@ -92,8 +94,12 @@ impl<T> Builder<T> {
             self.connect_timeout(connect_timeout);
         }
 
-        if let Some(request_timeout) = config.request_timeout() {
-            self.request_timeout(request_timeout);
+        if let Some(read_timeout) = config.read_timeout() {
+            self.read_timeout(read_timeout);
+        }
+
+        if let Some(write_timeout) = config.write_timeout() {
+            self.write_timeout(write_timeout);
         }
 
         if let Some(backoff_slot_size) = config.backoff_slot_size() {
@@ -195,20 +201,34 @@ impl<T> Builder<T> {
         self.connect_timeout
     }
 
-    /// Sets the request timeout.
+    /// Sets the read timeout.
     ///
-    /// This timeout applies to the entire duration of the request, from the first attempt to send it to the last read
-    /// of the response body.
+    /// This timeout applies to socket-level read attempts.
     ///
     /// Defaults to 5 minutes.
-    pub fn request_timeout(&mut self, request_timeout: Duration) -> &mut Self {
-        self.request_timeout = request_timeout;
+    pub fn read_timeout(&mut self, read_timeout: Duration) -> &mut Self {
+        self.read_timeout = read_timeout;
         self
     }
 
-    /// Returns the builder's configured request timeout.
-    pub fn get_request_timeout(&self) -> Duration {
-        self.request_timeout
+    /// Returns the builder's configured read timeout.
+    pub fn get_read_timeout(&self) -> Duration {
+        self.read_timeout
+    }
+
+    /// Sets the write timeout.
+    ///
+    /// This timeout applies to socket-level write attempts.
+    ///
+    /// Defaults to 5 minutes.
+    pub fn write_timeout(&mut self, write_timeout: Duration) -> &mut Self {
+        self.write_timeout = write_timeout;
+        self
+    }
+
+    /// Returns the builder's configured write timeout.
+    pub fn get_write_timeout(&self) -> Duration {
+        self.write_timeout
     }
 
     /// Sets the backoff slot size.
@@ -229,7 +249,7 @@ impl<T> Builder<T> {
 
     /// Sets the maximum number of times a request attempt will be retried before giving up.
     ///
-    /// Defaults to 3.
+    /// Defaults to 4.
     pub fn max_num_retries(&mut self, max_num_retries: u32) -> &mut Self {
         self.max_num_retries = max_num_retries;
         self
@@ -351,7 +371,8 @@ impl<T> Builder<T> {
             security: self.security,
             proxy: self.proxy,
             connect_timeout: self.connect_timeout,
-            request_timeout: self.request_timeout,
+            read_timeout: self.read_timeout,
+            write_timeout: self.write_timeout,
             backoff_slot_size: self.backoff_slot_size,
             max_num_retries: self.max_num_retries,
             server_qos: self.server_qos,

--- a/conjure-runtime/src/client.rs
+++ b/conjure-runtime/src/client.rs
@@ -22,7 +22,6 @@ use crate::service::request::RequestLayer;
 use crate::service::response::ResponseLayer;
 use crate::service::retry::RetryLayer;
 use crate::service::span::{SpanBody, SpanLayer};
-use crate::service::timeout::{TimeoutBody, TimeoutLayer};
 use crate::service::trace_propagation::TracePropagationLayer;
 use crate::service::user_agent::UserAgentLayer;
 use crate::service::{Identity, Layer, ServiceBuilder, Stack};
@@ -45,7 +44,6 @@ type BaseLayer = layers!(
     MetricsLayer,
     RequestLayer,
     ResponseLayer,
-    TimeoutLayer,
     RetryLayer,
     HttpErrorLayer,
     SpanLayer,
@@ -61,7 +59,7 @@ type BaseLayer = layers!(
 
 type BaseService<T> = <BaseLayer as Layer<T>>::Service;
 
-pub(crate) type BaseBody<B> = TimeoutBody<SpanBody<DecodedBody<B>>>;
+pub(crate) type BaseBody<B> = SpanBody<DecodedBody<B>>;
 
 pub(crate) struct ClientState<T> {
     service: BaseService<T>,
@@ -88,7 +86,6 @@ impl<T> ClientState<T> {
             .layer(MetricsLayer::new(service, builder))
             .layer(RequestLayer)
             .layer(ResponseLayer)
-            .layer(TimeoutLayer::new(builder.get_request_timeout()))
             .layer(RetryLayer::new(builder))
             .layer(HttpErrorLayer::new(builder))
             .layer(SpanLayer)

--- a/conjure-runtime/src/client_factory.rs
+++ b/conjure-runtime/src/client_factory.rs
@@ -119,6 +119,10 @@ impl ClientFactory {
     ///
     /// If no configuration is present for the specified service in the `ServicesConfig`, the client will
     /// immediately return an error for all requests.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `user_agent` is not set.
     pub fn client(&self, service: &str) -> Result<Client, Error> {
         let service_config = self.config.map({
             let service = service.to_string();
@@ -182,6 +186,10 @@ impl ClientFactory {
     ///
     /// If no configuration is present for the specified service in the `ServicesConfig`, the client will
     /// immediately return an error for all requests.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `user_agent` is not set.
     pub fn blocking_client(&self, service: &str) -> Result<blocking::Client, Error> {
         self.client(service).map(blocking::Client)
     }

--- a/conjure-runtime/src/errors.rs
+++ b/conjure-runtime/src/errors.rs
@@ -80,15 +80,3 @@ impl fmt::Display for UnavailableError {
 }
 
 impl Error for UnavailableError {}
-
-/// An error due to a request timing out.
-#[derive(Debug)]
-pub struct TimeoutError(pub(crate) ());
-
-impl fmt::Display for TimeoutError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("request timed out")
-    }
-}
-
-impl Error for TimeoutError {}

--- a/conjure-runtime/src/service/timeout.rs
+++ b/conjure-runtime/src/service/timeout.rs
@@ -11,61 +11,73 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::errors::TimeoutError;
-use crate::raw::Service;
-use crate::service::Layer;
-use conjure_error::Error;
+use crate::Builder;
+use bytes::{Buf, BufMut};
 use futures::ready;
-use http::{HeaderMap, Response};
-use http_body::{Body, SizeHint};
+use hyper::client::connect::{Connected, Connection};
 use pin_project::pin_project;
 use std::future::Future;
 use std::io;
+use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use tokio::time::{self, Delay};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tower::layer::Layer;
+use tower::Service;
 
-/// A layer which applies a timeout to an inner service's request, including the time waiting for ready.
+/// A connector layer which wraps a stream in a `TimeoutStream`.
 pub struct TimeoutLayer {
-    timeout: Duration,
+    read_timeout: Duration,
+    write_timeout: Duration,
 }
 
 impl TimeoutLayer {
-    pub fn new(timeout: Duration) -> TimeoutLayer {
-        TimeoutLayer { timeout }
+    pub fn new<T>(builder: &Builder<T>) -> TimeoutLayer {
+        TimeoutLayer {
+            read_timeout: builder.get_read_timeout(),
+            write_timeout: builder.get_write_timeout(),
+        }
     }
 }
 
 impl<S> Layer<S> for TimeoutLayer {
     type Service = TimeoutService<S>;
 
-    fn layer(self, inner: S) -> Self::Service {
+    fn layer(&self, inner: S) -> Self::Service {
         TimeoutService {
             inner,
-            timeout: self.timeout,
+            read_timeout: self.read_timeout,
+            write_timeout: self.write_timeout,
         }
     }
 }
 
+#[derive(Clone)]
 pub struct TimeoutService<S> {
     inner: S,
-    timeout: Duration,
+    read_timeout: Duration,
+    write_timeout: Duration,
 }
 
-impl<S, R, B> Service<R> for TimeoutService<S>
+impl<S, R> Service<R> for TimeoutService<S>
 where
-    S: Service<R, Response = Response<B>, Error = Error>,
-    B: Body,
+    S: Service<R>,
+    S::Response: AsyncRead + AsyncWrite + Unpin,
 {
-    type Response = Response<TimeoutBody<B>>;
-    type Error = Error;
+    type Response = TimeoutStream<S::Response>;
+    type Error = S::Error;
     type Future = TimeoutFuture<S::Future>;
 
-    fn call(&self, req: R) -> Self::Future {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
         TimeoutFuture {
             future: self.inner.call(req),
-            delay: time::delay_for(self.timeout),
+            read_timeout: self.read_timeout,
+            write_timeout: self.write_timeout,
         }
     }
 }
@@ -74,154 +86,177 @@ where
 pub struct TimeoutFuture<F> {
     #[pin]
     future: F,
-    #[pin]
-    delay: Delay,
+    read_timeout: Duration,
+    write_timeout: Duration,
 }
 
-impl<F, B> Future for TimeoutFuture<F>
+impl<F, S, E> Future for TimeoutFuture<F>
 where
-    F: Future<Output = Result<Response<B>, Error>>,
+    F: Future<Output = Result<S, E>>,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
-    type Output = Result<Response<TimeoutBody<B>>, Error>;
+    type Output = Result<TimeoutStream<S>, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.project();
+        let this = self.project();
 
-        if this.delay.as_mut().poll(cx).is_ready() {
-            return Poll::Ready(Err(Error::internal_safe(TimeoutError(()))));
-        }
+        let stream = ready!(this.future.poll(cx))?;
+        let mut stream = tokio_io_timeout::TimeoutStream::new(stream);
+        stream.set_read_timeout(Some(*this.read_timeout));
+        stream.set_write_timeout(Some(*this.write_timeout));
 
-        let response = ready!(this.future.poll(cx))?;
-
-        let deadline = this.delay.deadline();
-        Poll::Ready(Ok(response.map(|body| TimeoutBody {
-            body,
-            delay: time::delay_until(deadline),
-        })))
+        Poll::Ready(Ok(TimeoutStream { stream }))
     }
 }
 
 #[pin_project]
-pub struct TimeoutBody<B> {
+#[derive(Debug)]
+pub struct TimeoutStream<S> {
     #[pin]
-    body: B,
-    #[pin]
-    delay: Delay,
+    stream: tokio_io_timeout::TimeoutStream<S>,
 }
 
-impl<B> Body for TimeoutBody<B>
+impl<S> AsyncRead for TimeoutStream<S>
 where
-    B: Body<Error = io::Error>,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
-    type Data = B::Data;
-    type Error = io::Error;
-
-    fn poll_data(
+    fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
-        let this = self.project();
-
-        if this.delay.poll(cx).is_ready() {
-            return Poll::Ready(Some(Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                TimeoutError(()),
-            ))));
-        }
-
-        this.body.poll_data(cx)
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        self.project().stream.poll_read(cx, buf)
     }
 
-    fn poll_trailers(
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [MaybeUninit<u8>]) -> bool {
+        self.stream.prepare_uninitialized_buffer(buf)
+    }
+
+    fn poll_read_buf<B>(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
-        let this = self.project();
+        buf: &mut B,
+    ) -> Poll<io::Result<usize>>
+    where
+        B: BufMut,
+    {
+        self.project().stream.poll_read_buf(cx, buf)
+    }
+}
 
-        if this.delay.poll(cx).is_ready() {
-            return Poll::Ready(Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                TimeoutError(()),
-            )));
-        }
-
-        this.body.poll_trailers(cx)
+impl<S> AsyncWrite for TimeoutStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.project().stream.poll_write(cx, buf)
     }
 
-    fn is_end_stream(&self) -> bool {
-        self.body.is_end_stream()
+    fn poll_write_buf<B>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<io::Result<usize>>
+    where
+        B: Buf,
+    {
+        self.project().stream.poll_write_buf(cx, buf)
     }
 
-    fn size_hint(&self) -> SizeHint {
-        self.body.size_hint()
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().stream.poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().stream.poll_shutdown(cx)
+    }
+}
+
+impl<S> Connection for TimeoutStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Connection,
+{
+    fn connected(&self) -> Connected {
+        self.stream.get_ref().connected()
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::service;
+    use crate::Client;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::time;
 
-    struct TestBody;
+    #[tokio::test]
+    async fn read_no_timeout() {
+        time::pause();
 
-    impl Body for TestBody {
-        type Data = &'static [u8];
-        type Error = io::Error;
+        let mut service =
+            TimeoutLayer::new(&Client::builder()).layer(tower::service_fn(|_| async {
+                Ok::<_, ()>(tokio_test::io::Builder::new().read(b"hello").build())
+            }));
 
-        fn poll_data(
-            self: Pin<&mut Self>,
-            _: &mut Context<'_>,
-        ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
-            Poll::Ready(Some(Ok(b"hello world")))
-        }
+        let mut stream = service.call(()).await.unwrap();
+        let mut buf = vec![];
+        stream.read_to_end(&mut buf).await.unwrap();
 
-        fn poll_trailers(
-            self: Pin<&mut Self>,
-            _: &mut Context<'_>,
-        ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
-            Poll::Ready(Ok(None))
-        }
+        assert_eq!(buf, b"hello");
     }
 
     #[tokio::test]
-    async fn no_timeout() {
+    async fn read_timeout() {
         time::pause();
 
-        let service =
-            TimeoutLayer::new(Duration::from_secs(1)).layer(service::service_fn(|_| async move {
-                Ok(Response::new(TestBody))
+        let mut service = TimeoutLayer::new(Client::builder().read_timeout(Duration::from_secs(9)))
+            .layer(tower::service_fn(|_| async {
+                Ok::<_, ()>(
+                    tokio_test::io::Builder::new()
+                        .wait(Duration::from_secs(10))
+                        .read(b"hello")
+                        .build(),
+                )
             }));
 
-        service.call(()).await.unwrap();
+        let mut stream = service.call(()).await.unwrap();
+        let mut buf = vec![];
+        stream.read_to_end(&mut buf).await.unwrap_err();
     }
 
     #[tokio::test]
-    async fn timeout() {
+    async fn write_no_timeout() {
         time::pause();
 
-        let service =
-            TimeoutLayer::new(Duration::from_secs(1)).layer(service::service_fn(|_| async move {
-                time::advance(Duration::from_secs(2)).await;
-
-                Ok(Response::new(TestBody))
+        let mut service =
+            TimeoutLayer::new(&Client::builder()).layer(tower::service_fn(|_| async {
+                Ok::<_, ()>(tokio_test::io::Builder::new().write(b"hello").build())
             }));
 
-        service.call(()).await.err().unwrap();
+        let mut stream = service.call(()).await.unwrap();
+        stream.write_all(b"hello").await.unwrap();
     }
 
     #[tokio::test]
-    async fn body_timeout() {
+    async fn write_timeout() {
         time::pause();
 
-        let service =
-            TimeoutLayer::new(Duration::from_secs(1)).layer(service::service_fn(|_| async move {
-                Ok(Response::new(TestBody))
-            }));
+        let mut service = TimeoutLayer::new(
+            Client::builder().write_timeout(Duration::from_secs(9)),
+        )
+        .layer(tower::service_fn(|_| async {
+            Ok::<_, ()>(
+                tokio_test::io::Builder::new()
+                    .wait(Duration::from_secs(10))
+                    .write(b"hello")
+                    .build(),
+            )
+        }));
 
-        let mut response = service.call(()).await.unwrap();
-        assert_eq!(response.data().await.unwrap().unwrap(), b"hello world");
-
-        time::advance(Duration::from_secs(2)).await;
-        response.data().await.unwrap().err().unwrap();
+        let mut stream = service.call(()).await.unwrap();
+        stream.write_all(b"hello").await.unwrap_err();
     }
 }

--- a/simulation/src/simulation.rs
+++ b/simulation/src/simulation.rs
@@ -110,7 +110,6 @@ impl SimulationBuilder1 {
             .service(SERVICE)
             .user_agent(UserAgent::new(Agent::new("simulation", "0.0.0")))
             .metrics(self.metrics.clone())
-            .request_timeout(Duration::from_secs(1_000_000))
             .deterministic(true);
         for server in &self.servers {
             builder.uri(format!("http://{}", server.name()).parse().unwrap());


### PR DESCRIPTION
## Before this PR
We had a configurable request timeout which applied to the entire request, from sending request headers to reading the last byte of response body. This doesn't match with how c-j-r or Dialogue behave, however.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The request timeout has been replaced by socket-level read and write timeouts.
==COMMIT_MSG==

Closes #60 