### PR TITLE
Support the new mesh mode

### DIFF
--- a/changelog/@unreleased/pr-64.v2.yml
+++ b/changelog/@unreleased/pr-64.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+fix:
+  description: Added support for the new mesh proxy mode.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/64

--- a/conjure-runtime-config/Cargo.toml
+++ b/conjure-runtime-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime-config"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-runtime/src/client.rs
+++ b/conjure-runtime/src/client.rs
@@ -95,10 +95,12 @@ impl ClientState {
     }
 
     fn rewrite_for_mesh(service_config: &ServiceConfig) -> Result<Cow<ServiceConfig>, Error> {
+        let prefix = "mesh-";
+
         let mesh_uris = service_config
             .uris()
             .iter()
-            .filter(|uri| uri.scheme().starts_with("mesh-"))
+            .filter(|uri| uri.scheme().starts_with(prefix))
             .count();
 
         if mesh_uris == 0 {
@@ -115,7 +117,7 @@ impl ClientState {
         let old_uri = &service_config.uris()[0];
         let mut new_uri = old_uri.clone();
         new_uri
-            .set_scheme(old_uri.scheme().strip_prefix("mesh-").unwrap())
+            .set_scheme(&old_uri.scheme()[prefix.len()..])
             .unwrap();
 
         let config = ServiceConfigBuilder::from(service_config.clone())

--- a/conjure-runtime/src/client.rs
+++ b/conjure-runtime/src/client.rs
@@ -94,7 +94,7 @@ impl ClientState {
         })
     }
 
-    fn rewrite_for_mesh(service_config: &ServiceConfig) -> Result<Cow<ServiceConfig>, Error> {
+    fn rewrite_for_mesh(service_config: &ServiceConfig) -> Result<Cow<'_, ServiceConfig>, Error> {
         let prefix = "mesh-";
 
         let mesh_uris = service_config

--- a/conjure-runtime/src/client.rs
+++ b/conjure-runtime/src/client.rs
@@ -114,10 +114,8 @@ impl ClientState {
             );
         }
 
-        let old_uri = &service_config.uris()[0];
-        let mut new_uri = old_uri.clone();
-        new_uri
-            .set_scheme(&old_uri.scheme()[prefix.len()..])
+        let new_uri = service_config.uris()[0].as_str()[prefix.len()..]
+            .parse()
             .unwrap();
 
         let config = ServiceConfigBuilder::from(service_config.clone())

--- a/conjure-runtime/src/client.rs
+++ b/conjure-runtime/src/client.rs
@@ -19,12 +19,13 @@ use crate::{
 };
 use arc_swap::ArcSwap;
 use conjure_error::Error;
-use conjure_runtime_config::ServiceConfig;
+use conjure_runtime_config::{ServiceConfig, ServiceConfigBuilder};
 use hyper::client::HttpConnector;
 use hyper::header::HeaderValue;
 use hyper::Method;
 use hyper_openssl::HttpsConnector;
 use openssl::ssl::{SslConnector, SslMethod};
+use std::borrow::Cow;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 use witchcraft_log::info;
@@ -53,6 +54,8 @@ impl ClientState {
         host_metrics: &HostMetricsRegistry,
         service_config: &ServiceConfig,
     ) -> Result<ClientState, Error> {
+        let service_config = Self::rewrite_for_mesh(service_config)?;
+
         let mut connector = HttpConnector::new();
         connector.enforce_http(false);
         connector.set_nodelay(true);
@@ -79,7 +82,7 @@ impl ClientState {
             .pool_idle_timeout(HTTP_KEEPALIVE)
             .build(connector);
 
-        let node_selector = NodeSelector::new(service, host_metrics, service_config);
+        let node_selector = NodeSelector::new(service, host_metrics, &service_config);
 
         Ok(ClientState {
             client,
@@ -89,6 +92,38 @@ impl ClientState {
             request_timeout: service_config.request_timeout(),
             proxy,
         })
+    }
+
+    fn rewrite_for_mesh(service_config: &ServiceConfig) -> Result<Cow<ServiceConfig>, Error> {
+        let mesh_uris = service_config
+            .uris()
+            .iter()
+            .filter(|uri| uri.scheme().starts_with("mesh-"))
+            .count();
+
+        if mesh_uris == 0 {
+            return Ok(Cow::Borrowed(service_config));
+        }
+
+        if service_config.uris().len() != 1 {
+            return Err(
+                Error::internal_safe("exactly one URI must be present in mesh mode")
+                    .with_safe_param("uris", service_config.uris()),
+            );
+        }
+
+        let old_uri = &service_config.uris()[0];
+        let mut new_uri = old_uri.clone();
+        new_uri
+            .set_scheme(old_uri.scheme().strip_prefix("mesh-").unwrap())
+            .unwrap();
+
+        let config = ServiceConfigBuilder::from(service_config.clone())
+            .uris(vec![new_uri])
+            .max_num_retries(0)
+            .build();
+
+        Ok(Cow::Owned(config))
     }
 }
 

--- a/conjure-runtime/src/test.rs
+++ b/conjure-runtime/src/test.rs
@@ -799,3 +799,22 @@ impl Body for InfiniteBody {
         panic!("should not reset");
     }
 }
+
+#[tokio::test]
+async fn mesh_mode() {
+    test(
+        r#"
+services:
+  service:
+    uris: ["mesh-https://localhost:{{port}}"]
+    security:
+      ca-file: "{{ca_file}}"
+    "#,
+        1,
+        |_| async { Ok(Response::new(hyper::Body::empty())) },
+        |client| async move {
+            client.get("/").send().await.unwrap();
+        },
+    )
+    .await;
+}


### PR DESCRIPTION
This adds support for the new mesh proxy configuration, where there's a single URI with a `mesh-` prefix. Note that this is open against the 0.2.x branch since we want to get a release cut with this support for k8s testing stuff this year.