### PR TITLE
`#` is part of the query percent-encode set

### DIFF
--- a/changelog/@unreleased/pr-93.v2.yml
+++ b/changelog/@unreleased/pr-93.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed the percent-encoding logic to properly escape `#` characters.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/93

--- a/conjure-runtime-config/Cargo.toml
+++ b/conjure-runtime-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime-config"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -43,7 +43,7 @@ tower = "0.3"
 url = "2.0"
 zipkin = "0.4"
 
-conjure-runtime-config = { version = "0.3.0", path = "../conjure-runtime-config" }
+conjure-runtime-config = { version = "0.3.1", path = "../conjure-runtime-config" }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/conjure-runtime/src/service/request.rs
+++ b/conjure-runtime/src/service/request.rs
@@ -27,6 +27,7 @@ use zipkin::Bind;
 const QUERY: &AsciiSet = &percent_encoding::CONTROLS
     .add(b' ')
     .add(b'"')
+    .add(b'#')
     .add(b'<')
     .add(b'>');
 


### PR DESCRIPTION
## Before this PR
If a path or query parameter contained a `#` character, it would not be escaped. This caused the remainder of the URI to become the fragment which totally breaks parsing on the server side.

I double checked with the whatwg spec, and this appears to be the only character we were missing.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed the percent-encoding logic to properly escape `#` characters.
==COMMIT_MSG==
