### PR TITLE
Create tagged zipkin spans

### DIFF
--- a/changelog/@unreleased/pr-98.v2.yml
+++ b/changelog/@unreleased/pr-98.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The client now uses tags for the dynamic data in its zipkin spans.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/98

--- a/conjure-runtime-config/Cargo.toml
+++ b/conjure-runtime-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime-config"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -45,7 +45,7 @@ tower-service = "0.3"
 url = "2.0"
 zipkin = "0.4"
 
-conjure-runtime-config = { version = "0.4.1", path = "../conjure-runtime-config" }
+conjure-runtime-config = { version = "0.4.2", path = "../conjure-runtime-config" }
 
 [dev-dependencies]
 flate2 = "1.0"

--- a/conjure-runtime/src/conjure.rs
+++ b/conjure-runtime/src/conjure.rs
@@ -41,7 +41,7 @@ where
     T: Service<http::Request<raw::RawBody>, Response = http::Response<B>> + 'static + Sync + Send,
     T::Error: Into<Box<dyn error::Error + Sync + Send>>,
     T::Future: Send,
-    B: http_body::Body<Data = Bytes> + Send,
+    B: http_body::Body<Data = Bytes> + 'static + Sync + Send,
     B::Error: Into<Box<dyn error::Error + Sync + Send>>,
 {
     #[allow(clippy::too_many_arguments)]
@@ -85,7 +85,7 @@ where
     T: Service<http::Request<raw::RawBody>, Response = http::Response<B>> + 'static + Sync + Send,
     T::Error: Into<Box<dyn error::Error + Sync + Send>>,
     T::Future: Send,
-    B: http_body::Body<Data = Bytes> + Sync + Send,
+    B: http_body::Body<Data = Bytes> + 'static + Sync + Send,
     B::Error: Into<Box<dyn error::Error + Sync + Send>>,
 {
     type BinaryWriter = BodyWriter;

--- a/conjure-runtime/src/request.rs
+++ b/conjure-runtime/src/request.rs
@@ -118,7 +118,7 @@ where
     T: Service<http::Request<RawBody>, Response = http::Response<B>> + 'static + Sync + Send,
     T::Error: Into<Box<dyn error::Error + Sync + Send>>,
     T::Future: Send,
-    B: http_body::Body<Data = Bytes> + Send,
+    B: http_body::Body<Data = Bytes> + 'static + Sync + Send,
     B::Error: Into<Box<dyn error::Error + Sync + Send>>,
 {
     /// Makes the request.

--- a/conjure-runtime/src/service/mod.rs
+++ b/conjure-runtime/src/service/mod.rs
@@ -23,11 +23,12 @@ pub mod proxy;
 pub mod request;
 pub mod response;
 pub mod retry;
-pub mod span;
+pub mod root_span;
 pub mod timeout;
 pub mod tls_metrics;
 pub mod trace_propagation;
 pub mod user_agent;
+pub mod wait_for_spans;
 
 /// A function from one service type to another.
 ///

--- a/conjure-runtime/src/service/root_span.rs
+++ b/conjure-runtime/src/service/root_span.rs
@@ -1,0 +1,49 @@
+// Copyright 2020 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::service::{Layer, Service};
+use crate::util::spans::{self, HttpSpanFuture};
+use http::{Request, Response};
+
+/// A layer which manages the root level request span.
+pub struct RootSpanLayer;
+
+impl<S> Layer<S> for RootSpanLayer {
+    type Service = RootSpanService<S>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        RootSpanService { inner }
+    }
+}
+
+pub struct RootSpanService<S> {
+    inner: S,
+}
+
+impl<S, B1, B2> Service<Request<B1>> for RootSpanService<S>
+where
+    S: Service<Request<B1>, Response = Response<B2>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = HttpSpanFuture<S::Future>;
+
+    fn call(&self, req: Request<B1>) -> Self::Future {
+        let mut span = zipkin::next_span()
+            .with_name("conjure-runtime: request")
+            .detach();
+        spans::add_request_tags(&mut span, &req);
+
+        HttpSpanFuture::new(self.inner.call(req), span)
+    }
+}

--- a/conjure-runtime/src/service/root_span.rs
+++ b/conjure-runtime/src/service/root_span.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 use crate::service::{Layer, Service};
 use crate::util::spans::{self, HttpSpanFuture};
+use conjure_error::Error;
 use http::{Request, Response};
 
 /// A layer which manages the root level request span.
@@ -32,7 +33,7 @@ pub struct RootSpanService<S> {
 
 impl<S, B1, B2> Service<Request<B1>> for RootSpanService<S>
 where
-    S: Service<Request<B1>, Response = Response<B2>>,
+    S: Service<Request<B1>, Response = Response<B2>, Error = Error>,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/conjure-runtime/src/service/root_span.rs
+++ b/conjure-runtime/src/service/root_span.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::service::request::Pattern;
 use crate::service::{Layer, Service};
 use crate::util::spans::{self, HttpSpanFuture};
 use conjure_error::Error;
@@ -41,7 +42,11 @@ where
 
     fn call(&self, req: Request<B1>) -> Self::Future {
         let mut span = zipkin::next_span()
-            .with_name("conjure-runtime: request")
+            .with_name(&format!(
+                "conjure-runtime: {} {}",
+                req.method(),
+                req.extensions().get::<Pattern>().unwrap().pattern
+            ))
             .detach();
         spans::add_request_tags(&mut span, &req);
 

--- a/conjure-runtime/src/util/mod.rs
+++ b/conjure-runtime/src/util/mod.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 pub mod atomic_f64;
+pub mod spans;
 pub mod weak_reducing_gauge;

--- a/conjure-runtime/src/util/spans.rs
+++ b/conjure-runtime/src/util/spans.rs
@@ -23,9 +23,9 @@ use std::task::{Context, Poll};
 use zipkin::{Detached, OpenSpan};
 
 pub fn add_request_tags<A, B>(span: &mut OpenSpan<A>, request: &Request<B>) {
-    span.tag("method", request.method().as_str());
+    span.tag("http.method", request.method().as_str());
     span.tag(
-        "pattern",
+        "http.url_details.path",
         request
             .extensions()
             .get::<Pattern>()
@@ -72,7 +72,7 @@ where
                 };
                 span.tag("outcome", outcome);
                 // StatusCode::as_str returns the numeric representation, not the canonical reason.
-                span.tag("status", response.status().as_str());
+                span.tag("http.status_code", response.status().as_str());
             }
             Err(e) => {
                 span.tag("outcome", "failure");
@@ -88,7 +88,7 @@ where
                 };
 
                 if let Some(status) = status {
-                    span.tag("status", status.as_str());
+                    span.tag("http.status_code", status.as_str());
                 }
             }
         }

--- a/conjure-runtime/src/util/spans.rs
+++ b/conjure-runtime/src/util/spans.rs
@@ -1,0 +1,81 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::service::request::Pattern;
+use futures::ready;
+use http::{Request, Response};
+use pin_project::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use zipkin::{Detached, OpenSpan};
+
+pub fn add_request_tags<A, B>(span: &mut OpenSpan<A>, request: &Request<B>) {
+    span.tag("method", request.method().as_str());
+    span.tag(
+        "pattern",
+        request
+            .extensions()
+            .get::<Pattern>()
+            .expect("Pattern missing from request extensions")
+            .pattern,
+    );
+}
+
+#[pin_project]
+pub struct HttpSpanFuture<F> {
+    #[pin]
+    inner: F,
+    span: Option<OpenSpan<Detached>>,
+}
+
+impl<F> HttpSpanFuture<F> {
+    pub fn new(inner: F, span: OpenSpan<Detached>) -> Self {
+        HttpSpanFuture {
+            inner,
+            span: Some(span),
+        }
+    }
+}
+
+impl<F, B, E> Future for HttpSpanFuture<F>
+where
+    F: Future<Output = Result<Response<B>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        let span = this.span.as_mut().expect("future polled after completion");
+        let _guard = zipkin::set_current(span.context());
+        let r = ready!(this.inner.poll(cx));
+
+        match &r {
+            Ok(response) => {
+                let outcome = if response.status().is_success() {
+                    "success"
+                } else {
+                    "failure"
+                };
+                span.tag("outcome", outcome);
+                // StatusCode::as_str returns the numeric representation, not the canonical reason.
+                span.tag("status", response.status().as_str());
+            }
+            Err(_) => span.tag("outcome", "failure"),
+        }
+
+        *this.span = None;
+        Poll::Ready(r)
+    }
+}

--- a/conjure-verification-api/build.rs
+++ b/conjure-verification-api/build.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 use tar::Archive;
 
-const VERSION: &str = "0.18.3";
+const VERSION: &str = "0.19.0";
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -30,7 +30,7 @@ fn main() {
 
 fn download(name: &str, classifier: &str, extension: &str) -> Vec<u8> {
     let url = format!(
-        "https://palantir.bintray.com/releases/com/palantir/conjure/verification/{name}/{version}/{name}-{version}{classifier}.{extension}",
+        "https://repo1.maven.org/maven2/com/palantir/conjure/verification/{name}/{version}/{name}-{version}{classifier}.{extension}",
         name = name,
         version = VERSION,
         classifier = classifier,

--- a/conjure-verification/ignored-test-cases.yml
+++ b/conjure-verification/ignored-test-cases.yml
@@ -10,6 +10,7 @@ client:
       - '[]'
       - '[100, 10.0, "NaN", "Infinity", "-Infinity"]'
       - 'null'
+      - '{}'
     receiveMapDoubleAliasExample:
       - '{}'
       - '{"10": true}'
@@ -20,6 +21,8 @@ client:
       - '{"Infinity": true}'
       - '{"-Infinity": true}'
       - '{"10": true, "3e2": true}'
+      - 'null'
+      - '[]'
       - '{"10": true, "10e0": false}'
       - '{"10": true, "10.0": false}'
 
@@ -31,6 +34,7 @@ client:
     # serde_json follows Go's lead and only supports numeric non-string map keys
     receiveMapBooleanAliasExample:
       - '{"true": true}'
+      - 'null'
 
     # https://github.com/palantir/conjure-rust/issues/4
     receiveAnyExample:
@@ -94,6 +98,24 @@ client:
     receiveSetStringAliasExample:
       - 'null'
     receiveSetUuidAliasExample:
+      - 'null'
+    receiveMapBearerTokenAliasExample:
+      - 'null'
+    receiveMapBinaryAliasExample:
+      - 'null'
+    receiveMapDateTimeAliasExample:
+      - 'null'
+    receiveMapEnumExampleAlias:
+      - 'null'
+    receiveMapIntegerAliasExample:
+      - 'null'
+    receiveMapRidAliasExample:
+      - 'null'
+    receiveMapSafeLongAliasExample:
+      - 'null'
+    receiveMapStringAliasExample:
+      - 'null'
+    receiveMapUuidAliasExample:
       - 'null'
 
   singlePathParamService:


### PR DESCRIPTION
In the vein of https://github.com/palantir/dialogue/pull/1208, the client now no longer dynamically constructs span names and instead uses tags. We also now attach the overall outcome of a request and status code to the spans, both that the top level and per-attempt spans.