### PR TITLE
Allow configuration of the blocking client runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.55.0
     environment:
       RUSTFLAGS: -D warnings
     steps:

--- a/changelog/@unreleased/pr-103.v2.yml
+++ b/changelog/@unreleased/pr-103.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: The `tokio` runtime used by blocking clients can now be configured.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/103

--- a/conjure-runtime-config/Cargo.toml
+++ b/conjure-runtime-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime-config"
-version = "0.4.2"
+version = "1.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime"
-version = "0.4.2"
+version = "1.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -45,7 +45,7 @@ tower-service = "0.3"
 url = "2.0"
 zipkin = "0.4"
 
-conjure-runtime-config = { version = "0.4.2", path = "../conjure-runtime-config" }
+conjure-runtime-config = { version = "1.0.0", path = "../conjure-runtime-config" }
 
 [dev-dependencies]
 flate2 = "1.0"

--- a/conjure-runtime/src/blocking/client.rs
+++ b/conjure-runtime/src/blocking/client.rs
@@ -15,16 +15,23 @@ use crate::blocking::RequestBuilder;
 use crate::raw::DefaultRawClient;
 use crate::Builder;
 use http::Method;
+use tokio::runtime::Handle;
 
 /// A blocking HTTP client to a remote service.
 ///
 /// It implements the Conjure `Client` trait, but also offers a "raw" request interface for use with services that don't
 /// provide Conjure service definitions.
-pub struct Client<T = DefaultRawClient>(pub(crate) crate::Client<T>);
+pub struct Client<T = DefaultRawClient> {
+    pub(crate) client: crate::Client<T>,
+    pub(crate) handle: Option<Handle>,
+}
 
 impl<T> Clone for Client<T> {
     fn clone(&self) -> Self {
-        Client(self.0.clone())
+        Client {
+            client: self.client.clone(),
+            handle: self.handle.clone(),
+        }
     }
 }
 

--- a/conjure-runtime/src/errors.rs
+++ b/conjure-runtime/src/errors.rs
@@ -29,7 +29,7 @@ pub struct RemoteError {
 impl fmt::Display for RemoteError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.error() {
-            Some(ref error) => write!(
+            Some(error) => write!(
                 fmt,
                 "remote error: {} ({}) with instance ID {}",
                 error.error_code(),

--- a/conjure-runtime/src/raw/default.rs
+++ b/conjure-runtime/src/raw/default.rs
@@ -86,14 +86,14 @@ impl BuildRawClient for DefaultRawClientBuilder {
             }
         }
 
-        let proxy = ProxyConfig::from_config(&builder.get_proxy())?;
+        let proxy = ProxyConfig::from_config(builder.get_proxy())?;
 
         let connector = TimeoutLayer::new(builder).layer(connector);
         let connector = ProxyConnectorLayer::new(&proxy).layer(connector);
         let connector = HttpsLayer::with_connector(ssl)
             .map_err(Error::internal_safe)?
             .layer(connector);
-        let connector = TlsMetricsLayer::new(&service, builder).layer(connector);
+        let connector = TlsMetricsLayer::new(service, builder).layer(connector);
 
         let client = hyper::Client::builder()
             .pool_idle_timeout(HTTP_KEEPALIVE)

--- a/conjure-runtime/src/service/node/mod.rs
+++ b/conjure-runtime/src/service/node/mod.rs
@@ -109,7 +109,7 @@ impl LimitedNode {
             acquire: self
                 .limiter
                 .as_ref()
-                .map(|l| l.acquire(request.method(), &pattern.pattern)),
+                .map(|l| l.acquire(request.method(), pattern.pattern)),
             node: self.node.clone(),
         }
     }

--- a/conjure-runtime/src/util/spans.rs
+++ b/conjure-runtime/src/util/spans.rs
@@ -77,6 +77,7 @@ where
             Err(e) => {
                 span.tag("outcome", "failure");
 
+                #[allow(clippy::manual_map)] // cleaner as-is
                 let status = if e.cause().is::<ThrottledError>() {
                     Some(&StatusCode::TOO_MANY_REQUESTS)
                 } else if e.cause().is::<UnavailableError>() {

--- a/simulation/src/server.rs
+++ b/simulation/src/server.rs
@@ -72,7 +72,7 @@ impl<'a> ServerBuilder0<'a> {
     pub fn name(self, name: &str) -> ServerBuilder1<'a> {
         ServerBuilder1 {
             name: name.to_string(),
-            active_requests: metrics::active_requests(&self.metrics, name),
+            active_requests: metrics::active_requests(self.metrics, name),
             handlers: vec![],
             recorder: self.recorder,
         }


### PR DESCRIPTION
## Before this PR
Blocking clients always used their own multi-threaded tokio `Runtime`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The `tokio` runtime used by blocking clients can now be configured.
==COMMIT_MSG==

We already have a Runtime set up for the server side in our services, so it's just a waste of threads to not use that for the clients as well!