### PR TITLE
Use the configured handle for streaming responses

### DIFF
--- a/changelog/@unreleased/pr-105.v2.yml
+++ b/changelog/@unreleased/pr-105.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed usage of the configured runtime `Handle` in blocking response
+    bodies.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/105

--- a/conjure-runtime-config/Cargo.toml
+++ b/conjure-runtime-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime-config"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -45,7 +45,7 @@ tower-service = "0.3"
 url = "2.0"
 zipkin = "0.4"
 
-conjure-runtime-config = { version = "1.1.0", path = "../conjure-runtime-config" }
+conjure-runtime-config = { version = "1.2.0", path = "../conjure-runtime-config" }
 
 [dev-dependencies]
 flate2 = "1.0"

--- a/conjure-runtime/src/blocking/request.rs
+++ b/conjure-runtime/src/blocking/request.rs
@@ -146,7 +146,7 @@ where
         }
 
         match executor::block_on(receiver) {
-            Ok(Ok(r)) => Ok(Response::new(r)),
+            Ok(Ok(r)) => Ok(Response::new(r, handle.clone())),
             Ok(Err(e)) => Err(e.with_backtrace()),
             Err(e) => Err(Error::internal_safe(e)),
         }

--- a/conjure-runtime/src/blocking/response.rs
+++ b/conjure-runtime/src/blocking/response.rs
@@ -11,44 +11,52 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::blocking::runtime;
 use crate::raw::DefaultRawBody;
 use bytes::Bytes;
-use futures::executor;
-use futures::future;
 use http_body::Body;
 use hyper::{HeaderMap, StatusCode};
 use std::error;
 use std::io::{self, BufRead, Read};
 use std::pin::Pin;
+use tokio::io::AsyncBufReadExt;
 use tokio::io::{AsyncBufRead, AsyncReadExt};
+use tokio::runtime::Handle;
 
 /// A blocking HTTP response.
-pub struct Response<B = DefaultRawBody>(crate::Response<B>);
+pub struct Response<B = DefaultRawBody> {
+    inner: crate::Response<B>,
+    handle: Handle,
+}
 
 impl<B> Response<B> {
-    pub(crate) fn new(inner: crate::Response<B>) -> Response<B> {
-        Response(inner)
+    pub(crate) fn new(inner: crate::Response<B>, handle: Handle) -> Response<B> {
+        Response { inner, handle }
     }
 
     /// Returns the response's status.
     pub fn status(&self) -> StatusCode {
-        self.0.status()
+        self.inner.status()
     }
 
     /// Returns the response's headers.
     pub fn headers(&self) -> &HeaderMap {
-        self.0.headers()
+        self.inner.headers()
     }
 
     /// Consumes the response, returning its body.
     pub fn into_body(self) -> ResponseBody<B> {
-        ResponseBody(Box::pin(self.0.into_body()))
+        ResponseBody {
+            inner: Box::pin(self.inner.into_body()),
+            handle: self.handle,
+        }
     }
 }
 
 /// A blocking streaming response body.
-pub struct ResponseBody<B = DefaultRawBody>(Pin<Box<crate::ResponseBody<B>>>);
+pub struct ResponseBody<B = DefaultRawBody> {
+    inner: Pin<Box<crate::ResponseBody<B>>>,
+    handle: Handle,
+}
 
 impl<B> ResponseBody<B>
 where
@@ -60,8 +68,7 @@ where
     /// Compared to the `Read` implementation, this method avoids some copies of the body data when working with an API
     /// that already consumes `Bytes` objects.
     pub fn read_bytes(&mut self) -> io::Result<Option<Bytes>> {
-        let _guard = runtime()?.enter();
-        executor::block_on(self.0.as_mut().read_bytes())
+        self.handle.block_on(self.inner.as_mut().read_bytes())
     }
 }
 
@@ -71,8 +78,7 @@ where
     B::Error: Into<Box<dyn error::Error + Sync + Send>>,
 {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let _guard = runtime()?.enter();
-        executor::block_on(self.0.read(buf))
+        self.handle.block_on(self.inner.as_mut().read(buf))
     }
 }
 
@@ -83,14 +89,11 @@ where
 {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         // lifetime shenanigans mean we can't return the value of poll_fill_buf directly
-        let _guard = runtime()?.enter();
-        executor::block_on(future::poll_fn(|cx| {
-            self.0.as_mut().poll_fill_buf(cx).map_ok(|_| ())
-        }))?;
-        Ok(self.0.buffer())
+        self.handle.block_on(self.inner.as_mut().fill_buf())?;
+        Ok(self.inner.buffer())
     }
 
     fn consume(&mut self, n: usize) {
-        self.0.as_mut().consume(n)
+        self.inner.as_mut().consume(n)
     }
 }


### PR DESCRIPTION
## Before this PR
#103 forgot to propagate the configured runtime handle into the blocking streaming response type, leading to accidental use of the conjure-runtime internal Runtime even when configured to use another one.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed usage of the configured runtime `Handle` in blocking response bodies.
==COMMIT_MSG==

