### PR TITLE
Auto-wrap clients returned from ClientFactory in services

### DIFF
--- a/changelog/@unreleased/pr-119.v2.yml
+++ b/changelog/@unreleased/pr-119.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: '`ClientFactory`''s `client` and `blocking_client` methods now automatically
+    wrap the client in a Conjure service.'
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/119

--- a/conjure-runtime-config/Cargo.toml
+++ b/conjure-runtime-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime-config"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -48,7 +48,7 @@ tower-service = "0.3"
 url = "2.0"
 zipkin = "0.4"
 
-conjure-runtime-config = { version = "2.0.0", path = "../conjure-runtime-config" }
+conjure-runtime-config = { version = "2.1.0", path = "../conjure-runtime-config" }
 
 [dev-dependencies]
 flate2 = "1.0"

--- a/conjure-runtime/src/blocking/client.rs
+++ b/conjure-runtime/src/blocking/client.rs
@@ -16,7 +16,7 @@ use crate::raw::{DefaultRawClient, RawBody, Service};
 use crate::Builder;
 use bytes::Bytes;
 use conjure_error::Error;
-use conjure_http::client::{AsyncBody, AsyncClient, Body};
+use conjure_http::client::{self, AsyncBody, AsyncClient, Body};
 use futures::channel::oneshot;
 use futures::executor;
 use http::{Request, Response};
@@ -63,6 +63,12 @@ impl Client {
     /// Returns a new `Builder` for clients.
     pub fn builder() -> Builder {
         Builder::new()
+    }
+}
+
+impl<T> client::Service<Client<T>> for Client<T> {
+    fn new(client: Client<T>) -> Self {
+        client
     }
 }
 

--- a/conjure-runtime/src/client.rs
+++ b/conjure-runtime/src/client.rs
@@ -30,7 +30,7 @@ use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use bytes::Bytes;
 use conjure_error::Error;
-use conjure_http::client::{AsyncBody, AsyncClient};
+use conjure_http::client::{AsyncBody, AsyncClient, AsyncService};
 use conjure_runtime_config::ServiceConfig;
 use http::{Request, Response};
 use refreshable::Subscription;
@@ -133,6 +133,12 @@ impl<T> Client<T> {
             state,
             subscription: subscription.map(Arc::new),
         }
+    }
+}
+
+impl<T> AsyncService<Client<T>> for Client<T> {
+    fn new(client: Client<T>) -> Self {
+        client
     }
 }
 


### PR DESCRIPTION
## Before this PR
Users of e.g. witchcraft-server's `ClientFactory` had to manually wrap the returned client in the Conjure service they want to use.

## After this PR
==COMMIT_MSG==
`ClientFactory`'s `client` and `blocking_client` methods now automatically wrap the client in a Conjure service.
==COMMIT_MSG==

Closes #118 

## Possible downsides?
This could cause compilation failures in contexts where the compiler can't infer that the returned type should be `Client`. However, the 2.0 release hasn't been out for very long anyways so I don't think it's all that risky in practice.