### PR TITLE
Don't panic on invalid user agent versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.56.0
+      - image: rust:1.62.0
     environment:
       RUSTFLAGS: -D warnings
     steps:
@@ -39,5 +39,5 @@ jobs:
       - run: cargo test -p conjure-runtime-config
       - run: cargo test -p conjure-verification
       # running unoptimized simulations is slower than building + running optimized simulations
-      - run: cargo test -p simulation --release 
+      - run: cargo test -p simulation --release
       - *SAVE_DEPS

--- a/changelog/@unreleased/pr-132.v2.yml
+++ b/changelog/@unreleased/pr-132.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Invalid user agent versions are now replaced with `0.0.0` rather than
+    panicking.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/132

--- a/conjure-runtime-config/Cargo.toml
+++ b/conjure-runtime-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime-config"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-runtime-config/src/lib.rs
+++ b/conjure-runtime-config/src/lib.rs
@@ -132,13 +132,8 @@ impl ServicesConfig {
 }
 
 /// A builder type for `ServiceConfig`.
+#[derive(Default)]
 pub struct ServicesConfigBuilder(ServicesConfig);
-
-impl Default for ServicesConfigBuilder {
-    fn default() -> ServicesConfigBuilder {
-        ServicesConfigBuilder(ServicesConfig::default())
-    }
-}
 
 impl From<ServicesConfig> for ServicesConfigBuilder {
     fn from(config: ServicesConfig) -> ServicesConfigBuilder {
@@ -370,13 +365,8 @@ impl SecurityConfig {
 }
 
 /// A builder type for `SecurityConfig`s.
+#[derive(Default)]
 pub struct SecurityConfigBuilder(SecurityConfig);
-
-impl Default for SecurityConfigBuilder {
-    fn default() -> SecurityConfigBuilder {
-        SecurityConfigBuilder(SecurityConfig::default())
-    }
-}
 
 impl From<SecurityConfig> for SecurityConfigBuilder {
     fn from(config: SecurityConfig) -> SecurityConfigBuilder {
@@ -452,18 +442,10 @@ impl HttpProxyConfig {
 }
 
 /// A builder for `HttpProxyConfig`s.
+#[derive(Default)]
 pub struct HttpProxyConfigBuilder {
     host_and_port: Option<HostAndPort>,
     credentials: Option<BasicCredentials>,
-}
-
-impl Default for HttpProxyConfigBuilder {
-    fn default() -> HttpProxyConfigBuilder {
-        HttpProxyConfigBuilder {
-            host_and_port: None,
-            credentials: None,
-        }
-    }
 }
 
 impl From<HttpProxyConfig> for HttpProxyConfigBuilder {

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-runtime"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -48,7 +48,7 @@ tower-service = "0.3"
 url = "2.0"
 zipkin = "0.4"
 
-conjure-runtime-config = { version = "3.0.0", path = "../conjure-runtime-config" }
+conjure-runtime-config = { version = "3.1.0", path = "../conjure-runtime-config" }
 
 [dev-dependencies]
 flate2 = "1.0"

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -54,7 +54,7 @@ conjure-runtime-config = { version = "3.0.0", path = "../conjure-runtime-config"
 flate2 = "1.0"
 futures-test = "0.3"
 hyper = { version = "0.14", features = ["server"] }
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 tokio-openssl = "0.6"
 tokio-test = "0.4"
 tokio = { version = "1.0", features = ["full"] }

--- a/conjure-runtime/src/user_agent.rs
+++ b/conjure-runtime/src/user_agent.rs
@@ -153,7 +153,7 @@ mod test {
 
     #[test]
     fn version_fallback() {
-        let agent = UserAgent::new(Agent::new("foobar", "some-invalid-version"));
-        assert_eq!(agent.primary().version(), "0.0.0");
+        let agent = Agent::new("foobar", "some-invalid-version");
+        assert_eq!(agent.version(), "0.0.0");
     }
 }

--- a/conjure-verification-api/Cargo.toml
+++ b/conjure-verification-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-verification-api"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 publish = false

--- a/conjure-verification/Cargo.toml
+++ b/conjure-verification/Cargo.toml
@@ -11,7 +11,7 @@ harness = false
 
 [build-dependencies]
 conjure-serde = "2"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 heck = "0.4"
 syn = "1.0"
 quote = "1.0"

--- a/conjure-verification/Cargo.toml
+++ b/conjure-verification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-verification"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 publish = false

--- a/simulation/Cargo.toml
+++ b/simulation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simulation"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
## Before this PR
An invalid product version in a Witchcraft server (e.g. one generated with a `.dirty` suffix would cause the server to panic on startup.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Invalid user agent versions are now replaced with `0.0.0` rather than panicking.
==COMMIT_MSG==

This matches conjure-java-runtime's behavior: https://github.com/palantir/conjure-java-runtime-api/blob/develop/service-config/src/main/java/com/palantir/conjure/java/api/config/service/UserAgent.java#L101.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

