### PR TITLE
Bump version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "4.5.0"
+version = "4.6.1"
 
 [workspace]
 members = [

--- a/changelog/@unreleased/pr-164.v2.yml
+++ b/changelog/@unreleased/pr-164.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Bump version in Cargo.toml
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/164

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1.0"
 conjure-error = "3.6"
 conjure-http = "3.6"
 conjure-object = "3.6"
-conjure-runtime-config = { version = "4.5.0", path = "../conjure-runtime-config" }
+conjure-runtime-config = { version = "4.6.1", path = "../conjure-runtime-config" }
 conjure-serde = "3.6"
 flate2 = "1.0"
 futures = "0.3"


### PR DESCRIPTION
Oops, I forgot to bump the version in Cargo.toml autoreleasing 4.6.0. This will release a 4.6.1.