### PR TITLE
Propagate fixed size request body sizes

### DIFF
--- a/changelog/@unreleased/pr-209.v2.yml
+++ b/changelog/@unreleased/pr-209.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed-size request bodies now set a `Content-Length`.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/209

--- a/conjure-runtime/src/raw/body.rs
+++ b/conjure-runtime/src/raw/body.rs
@@ -17,6 +17,7 @@ use conjure_error::Error;
 use conjure_http::client::{AsyncRequestBody, AsyncWriteBody};
 use futures::channel::{mpsc, oneshot};
 use futures::{pin_mut, Stream};
+use http_body::SizeHint;
 use hyper::HeaderMap;
 use pin_project::pin_project;
 use std::io::Cursor;
@@ -145,6 +146,14 @@ impl http_body::Body for RawBody {
 
     fn is_end_stream(&self) -> bool {
         matches!(self.inner, RawBodyInner::Empty)
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        match &self.inner {
+            RawBodyInner::Empty => SizeHint::with_exact(0),
+            RawBodyInner::Single(buf) => SizeHint::with_exact(buf.len() as u64),
+            RawBodyInner::Stream { .. } => SizeHint::new(),
+        }
     }
 }
 

--- a/conjure-runtime/src/test.rs
+++ b/conjure-runtime/src/test.rs
@@ -755,7 +755,7 @@ security:
 }
 
 #[tokio::test]
-async fn empty_body_has_content_length() {
+async fn empty_body_has_no_transfer_encoding() {
     test(
         STOCK_CONFIG,
         1,

--- a/conjure-runtime/src/test.rs
+++ b/conjure-runtime/src/test.rs
@@ -24,7 +24,7 @@ use conjure_runtime_config::ServiceConfig;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures::{join, pin_mut};
-use http::header::CONTENT_LENGTH;
+use http::header::{CONTENT_LENGTH, TRANSFER_ENCODING};
 use http::{request, Method};
 use hyper::body;
 use hyper::header::{ACCEPT_ENCODING, CONTENT_ENCODING};
@@ -755,14 +755,14 @@ security:
 }
 
 #[tokio::test]
-#[ignore = "https://github.com/hyperium/hyper/issues/3654"]
 async fn empty_body_has_content_length() {
     test(
         STOCK_CONFIG,
         1,
         |req| async move {
             println!("{:#?}", req.headers());
-            assert_eq!(req.headers().get(CONTENT_LENGTH).unwrap(), "0");
+            assert_eq!(req.headers().get(CONTENT_LENGTH), None);
+            assert_eq!(req.headers().get(TRANSFER_ENCODING), None);
             Ok(Response::new(hyper::Body::empty()))
         },
         |builder| async move {
@@ -789,6 +789,7 @@ async fn fixed_body_has_content_length() {
         1,
         |req| async move {
             assert_eq!(req.headers().get(CONTENT_LENGTH).unwrap(), "4");
+            assert_eq!(req.headers().get(TRANSFER_ENCODING), None);
             Ok(Response::new(hyper::Body::empty()))
         },
         |builder| async move {

--- a/conjure-runtime/src/test.rs
+++ b/conjure-runtime/src/test.rs
@@ -760,7 +760,6 @@ async fn empty_body_has_content_length() {
         STOCK_CONFIG,
         1,
         |req| async move {
-            println!("{:#?}", req.headers());
             assert_eq!(req.headers().get(CONTENT_LENGTH), None);
             assert_eq!(req.headers().get(TRANSFER_ENCODING), None);
             Ok(Response::new(hyper::Body::empty()))


### PR DESCRIPTION
## Before this PR
Fixed-size request bodies didn't have their sizes propagated to Hyper properly, and so were sent out with `Transfer-Encoding: chunked`. This is a bit inefficient, and trips up some poorly-behaved servers that don't support chunked transfers (!??!).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed-size request bodies now set a `Content-Length`.
==COMMIT_MSG==

