### PR TITLE
[backport] Propagate fixed size request body sizes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.65.0
+      - image: rust:1.75.0
     environment:
       RUSTFLAGS: -D warnings
     steps:

--- a/changelog/@unreleased/pr-209.v2.yml
+++ b/changelog/@unreleased/pr-209.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed-size request bodies now set a `Content-Length`.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/209

--- a/conjure-runtime/src/raw/body.rs
+++ b/conjure-runtime/src/raw/body.rs
@@ -17,6 +17,7 @@ use conjure_error::Error;
 use conjure_http::client::{AsyncRequestBody, AsyncWriteBody};
 use futures::channel::{mpsc, oneshot};
 use futures::{pin_mut, Stream};
+use http_body::SizeHint;
 use hyper::HeaderMap;
 use pin_project::pin_project;
 use std::io::Cursor;
@@ -145,6 +146,14 @@ impl http_body::Body for RawBody {
 
     fn is_end_stream(&self) -> bool {
         matches!(self.inner, RawBodyInner::Empty)
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        match &self.inner {
+            RawBodyInner::Empty => SizeHint::with_exact(0),
+            RawBodyInner::Single(buf) => SizeHint::with_exact(buf.len() as u64),
+            RawBodyInner::Stream { .. } => SizeHint::new(),
+        }
     }
 }
 

--- a/conjure-runtime/src/service/proxy/mod.rs
+++ b/conjure-runtime/src/service/proxy/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 use crate::config;
 pub use crate::service::proxy::connector::{ProxyConnectorLayer, ProxyConnectorService};
-pub use crate::service::proxy::request::{ProxyLayer, ProxyService};
+pub use crate::service::proxy::request::ProxyLayer;
 use base64::display::Base64Display;
 use base64::engine::general_purpose::STANDARD;
 use conjure_error::Error;

--- a/conjure-runtime/src/test.rs
+++ b/conjure-runtime/src/test.rs
@@ -24,6 +24,7 @@ use conjure_runtime_config::ServiceConfig;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures::{join, pin_mut};
+use http::header::{CONTENT_LENGTH, TRANSFER_ENCODING};
 use http::{request, Method};
 use hyper::body;
 use hyper::header::{ACCEPT_ENCODING, CONTENT_ENCODING};
@@ -747,6 +748,60 @@ security:
                 .build()
                 .unwrap()
                 .send(req().body(AsyncRequestBody::Empty).unwrap())
+                .await
+                .unwrap();
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn empty_body_has_no_transfer_encoding() {
+    test(
+        STOCK_CONFIG,
+        1,
+        |req| async move {
+            assert_eq!(req.headers().get(CONTENT_LENGTH), None);
+            assert_eq!(req.headers().get(TRANSFER_ENCODING), None);
+            Ok(Response::new(hyper::Body::empty()))
+        },
+        |builder| async move {
+            builder
+                .build()
+                .unwrap()
+                .send(
+                    req()
+                        .method(Method::POST)
+                        .body(AsyncRequestBody::Empty)
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn fixed_body_has_content_length() {
+    test(
+        STOCK_CONFIG,
+        1,
+        |req| async move {
+            assert_eq!(req.headers().get(CONTENT_LENGTH).unwrap(), "4");
+            assert_eq!(req.headers().get(TRANSFER_ENCODING), None);
+            Ok(Response::new(hyper::Body::empty()))
+        },
+        |builder| async move {
+            builder
+                .build()
+                .unwrap()
+                .send(
+                    req()
+                        .method(Method::POST)
+                        .body(AsyncRequestBody::Fixed(Bytes::from_static(b"1234")))
+                        .unwrap(),
+                )
                 .await
                 .unwrap();
         },


### PR DESCRIPTION
Propagate fixed size request body sizes

(cherry picked from commit 37d1a08d9ccef5d12fb2961c363f55785fea7a77)