### PR TITLE
Explicitly configure the rustls crypto provider

### DIFF
--- a/changelog/@unreleased/pr-221.v2.yml
+++ b/changelog/@unreleased/pr-221.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Explicitly configure rustls's crypto provider.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/221


### PR DESCRIPTION
## Before this PR
We depended on rustls's default crypto provider resolution, which can stop working if e.g. transitive dependencies enable the `ring` provider backend.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Explicitly configure rustls's crypto provider.
==COMMIT_MSG==

