### PR TITLE
Propagate error instance ID from remote errors

### DIFF
--- a/changelog/@unreleased/pr-235.v2.yml
+++ b/changelog/@unreleased/pr-235.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The error instance ID of remote errors is now propagated.
+  links:
+  - https://github.com/palantir/conjure-rust-runtime/pull/235

--- a/conjure-runtime/src/service/http_error.rs
+++ b/conjure-runtime/src/service/http_error.rs
@@ -16,7 +16,7 @@ use crate::raw::Service;
 use crate::service::Layer;
 use crate::{builder, Builder, ServerQos, ServiceError};
 use bytes::{BufMut, BytesMut};
-use conjure_error::Error;
+use conjure_error::{Error, ErrorType, Internal};
 use conjure_serde::json;
 use futures::StreamExt;
 use http::header::RETRY_AFTER;
@@ -149,9 +149,11 @@ where
                         let e = e.clone();
                         Error::propagated_service_safe(error, e)
                     }
-                    (Some(_), ServiceError::WrapInNewError) | (None, _) => {
-                        Error::internal_safe(error)
+                    (Some(e), ServiceError::WrapInNewError) => {
+                        let instance_id = e.error_instance_id();
+                        Error::service_safe(error, Internal::new().with_instance_id(instance_id))
                     }
+                    (None, _) => Error::internal_safe(error),
                 };
 
                 if log_body {
@@ -300,7 +302,7 @@ mod test {
             _ => panic!("expected a service error"),
         };
         assert_eq!(*service.error_code(), ErrorCode::Internal);
-        assert_ne!(
+        assert_eq!(
             service.error_instance_id(),
             service_error.error_instance_id()
         );


### PR DESCRIPTION
## Before this PR
By default, Conjure errors received from other services would turn into an error that would not propagate any of the upstream info, including its instance ID. This doesn't match the behavior of conjure-java as of https://github.com/palantir/conjure-java-runtime-api/pull/348.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The error instance ID of remote errors is now propagated.
==COMMIT_MSG==



