### PR TITLE
Remove mandatory Send bound in Service API

### DIFF
--- a/conjure-runtime/src/service/gzip.rs
+++ b/conjure-runtime/src/service/gzip.rs
@@ -48,8 +48,7 @@ pub struct GzipService<S> {
 
 impl<S, B1, B2> Service<Request<B1>> for GzipService<S>
 where
-    S: Service<Request<B1>, Response = Response<B2>> + Sync + Send,
-    B1: Sync + Send,
+    S: Service<Request<B1>, Response = Response<B2>>,
     B2: Body<Data = Bytes>,
     B2::Error: Into<Box<dyn Error + Sync + Send>>,
 {

--- a/conjure-runtime/src/service/http_error.rs
+++ b/conjure-runtime/src/service/http_error.rs
@@ -71,10 +71,8 @@ pub struct HttpErrorService<S> {
 
 impl<S, B1, B2> Service<Request<B1>> for HttpErrorService<S>
 where
-    S: Service<Request<B1>, Response = Response<B2>, Error = Error> + Sync + Send,
-    B1: Sync + Send,
-    B2: Body + Send,
-    B2::Data: Send,
+    S: Service<Request<B1>, Response = Response<B2>, Error = Error>,
+    B2: Body,
     B2::Error: Into<Box<dyn error::Error + Sync + Send>>,
 {
     type Response = Response<B2>;

--- a/conjure-runtime/src/service/map_error.rs
+++ b/conjure-runtime/src/service/map_error.rs
@@ -49,9 +49,8 @@ pub struct MapErrorService<S> {
 
 impl<S, R> Service<R> for MapErrorService<S>
 where
-    S: Service<R> + Sync + Send,
+    S: Service<R>,
     S::Error: Into<Box<dyn error::Error + Sync + Send>>,
-    R: Sync + Send,
 {
     type Response = S::Response;
     type Error = Error;

--- a/conjure-runtime/src/service/metrics.rs
+++ b/conjure-runtime/src/service/metrics.rs
@@ -62,8 +62,7 @@ pub struct MetricsService<S> {
 
 impl<S, B1, B2> Service<Request<B1>> for MetricsService<S>
 where
-    S: Service<Request<B1>, Response = Response<B2>, Error = Error> + Sync + Send,
-    B1: Send,
+    S: Service<Request<B1>, Response = Response<B2>, Error = Error>,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/conjure-runtime/src/service/mod.rs
+++ b/conjure-runtime/src/service/mod.rs
@@ -41,7 +41,7 @@ pub trait Service<R> {
     type Error;
 
     /// Asynchronously perform the request.
-    fn call(&self, req: R) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send;
+    async fn call(&self, req: R) -> Result<Self::Response, Self::Error>;
 }
 
 /// A function from one service type to another.
@@ -133,7 +133,7 @@ pub struct ServiceFn<T>(T);
 impl<T, R, F, S, E> Service<R> for ServiceFn<T>
 where
     T: Fn(R) -> F,
-    F: Future<Output = Result<S, E>> + Send,
+    F: Future<Output = Result<S, E>>,
 {
     type Response = S;
     type Error = E;

--- a/conjure-runtime/src/service/node/metrics.rs
+++ b/conjure-runtime/src/service/node/metrics.rs
@@ -34,8 +34,7 @@ pub struct NodeMetricsService<S> {
 
 impl<S, B1, B2> Service<Request<B1>> for NodeMetricsService<S>
 where
-    S: Service<Request<B1>, Response = Response<B2>> + Sync + Send,
-    B1: Sync + Send,
+    S: Service<Request<B1>, Response = Response<B2>>,
 {
     type Error = S::Error;
     type Response = S::Response;

--- a/conjure-runtime/src/service/node/selector/balanced/mod.rs
+++ b/conjure-runtime/src/service/node/selector/balanced/mod.rs
@@ -233,9 +233,8 @@ where
 
 impl<S, T, B1, B2> Service<Request<B1>> for BalancedNodeSelectorService<S, T>
 where
-    T: Entropy + Sync + Send,
-    S: Service<Request<B1>, Response = Response<B2>, Error = Error> + Sync + Send,
-    B1: Sync + Send,
+    T: Entropy,
+    S: Service<Request<B1>, Response = Response<B2>, Error = Error>,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/conjure-runtime/src/service/node/selector/empty.rs
+++ b/conjure-runtime/src/service/node/selector/empty.rs
@@ -48,8 +48,7 @@ pub struct EmptyNodeSelectorService<S> {
 
 impl<S, B> Service<Request<B>> for EmptyNodeSelectorService<S>
 where
-    S: Service<Request<B>, Error = Error> + Sync,
-    B: Send,
+    S: Service<Request<B>, Error = Error>,
 {
     type Response = S::Response;
     type Error = Error;

--- a/conjure-runtime/src/service/node/selector/mod.rs
+++ b/conjure-runtime/src/service/node/selector/mod.rs
@@ -110,8 +110,7 @@ pub enum NodeSelectorService<S> {
 
 impl<S, B1, B2> Service<Request<B1>> for NodeSelectorService<S>
 where
-    S: Service<Request<B1>, Response = Response<B2>, Error = Error> + Sync + Send,
-    B1: Sync + Send,
+    S: Service<Request<B1>, Response = Response<B2>, Error = Error>,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/conjure-runtime/src/service/node/selector/pin_until_error.rs
+++ b/conjure-runtime/src/service/node/selector/pin_until_error.rs
@@ -202,9 +202,8 @@ pub struct PinUntilErrorNodeSelectorService<T, S> {
 
 impl<T, S, B1, B2> Service<Request<B1>> for PinUntilErrorNodeSelectorService<T, S>
 where
-    T: Nodes<LimitedNode> + Sync + Send,
-    S: Service<Request<B1>, Response = Response<B2>, Error = Error> + Sync + Send,
-    B1: Sync + Send,
+    T: Nodes<LimitedNode>,
+    S: Service<Request<B1>, Response = Response<B2>, Error = Error>,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/conjure-runtime/src/service/node/selector/single.rs
+++ b/conjure-runtime/src/service/node/selector/single.rs
@@ -48,8 +48,7 @@ pub struct SingleNodeSelectorService<S> {
 
 impl<S, B1, B2> Service<Request<B1>> for SingleNodeSelectorService<S>
 where
-    S: Service<Request<B1>, Response = Response<B2>, Error = Error> + Sync + Send,
-    B1: Sync + Send,
+    S: Service<Request<B1>, Response = Response<B2>, Error = Error>,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/conjure-runtime/src/service/response_body.rs
+++ b/conjure-runtime/src/service/response_body.rs
@@ -32,8 +32,7 @@ pub struct ResponseBodyService<S> {
 
 impl<S, R> Service<R> for ResponseBodyService<S>
 where
-    S: Service<R, Response = Response<BaseBody>> + Sync + Send,
-    R: Send,
+    S: Service<R, Response = Response<BaseBody>>,
 {
     type Response = Response<ResponseBody>;
     type Error = S::Error;

--- a/conjure-runtime/src/service/retry.rs
+++ b/conjure-runtime/src/service/retry.rs
@@ -82,8 +82,7 @@ pub struct RetryService<S> {
 
 impl<'a, S, B> Service<Request<AsyncRequestBody<'a, BodyWriter>>> for RetryService<S>
 where
-    S: Service<Request<RawRequestBody>, Response = Response<B>, Error = Error> + 'a + Sync + Send,
-    S::Response: Send,
+    S: Service<Request<RawRequestBody>, Response = Response<B>, Error = Error> + 'a,
     B: 'static,
 {
     type Response = S::Response;

--- a/conjure-runtime/src/service/wait_for_spans.rs
+++ b/conjure-runtime/src/service/wait_for_spans.rs
@@ -37,8 +37,7 @@ pub struct WaitForSpansService<S> {
 
 impl<S, R, B> Service<R> for WaitForSpansService<S>
 where
-    S: Service<R, Response = Response<B>> + Sync + Send,
-    R: Send,
+    S: Service<R, Response = Response<B>>,
 {
     type Response = Response<WaitForSpansBody<B>>;
     type Error = S::Error;


### PR DESCRIPTION
## Before this PR
We required all of the Service layers to create Send futures.

## After this PR
This requirement isn't actually necessary - we just need the final concrete aggregate future to be Send. Removing the requirement makes the non-Send wasm implementation possible.

This is a purely internal refactor that doesn't affect the public API.

