### PR TITLE
add duplex half to get fetch working in browsers

### DIFF
--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -11,11 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::service::raw::RawRequestBody;
+use crate::service::raw::{RawRequestBody, RequestBodyError};
 use crate::service::Service;
 use crate::{builder, Builder};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use conjure_error::Error;
+use futures::TryStreamExt;
 use http::{header, HeaderName, HeaderValue, Request, Response, StatusCode};
 use http_body::{Body, Frame};
 use http_body_util::BodyExt;
@@ -172,30 +173,32 @@ impl Body for RawResponseBody {
     }
 }
 
-async fn read_body(mut body: RawRequestBody, limit: usize) -> Result<Vec<u8>, JsError> {
-    let mut data = Vec::new();
+async fn read_body(body: RawRequestBody, limit: usize) -> Result<Bytes, JsError> {
+    let mut data_stream = body.into_data_stream();
 
-    match body.frame().await {
-        Some(result) => {
-            let frame = result.map_err(|e| JsError::new((&e.to_string()).into()))?;
-            if let Some(chunk) = frame.data_ref() {
-                data.extend_from_slice(chunk);
-            }
+    let first = match data_stream.try_next().await? {
+        Some(bytes) => bytes,
+        None => return Ok(Bytes::new()),
+    };
+    check_limit(&first, limit)?;
+
+    let mut buf = BytesMut::new();
+    match data_stream.try_next().await? {
+        Some(second) => {
+            buf.reserve(first.len() + second.len());
+            buf.extend_from_slice(&first);
+            buf.extend_from_slice(&second);
         }
-        None => return Ok(data),
+        None => return Ok(first),
+    }
+    check_limit(&first, limit)?;
+
+    while let Some(bytes) = data_stream.try_next().await? {
+        buf.extend_from_slice(&bytes);
+        check_limit(&buf, limit)?;
     }
 
-    check_limit(&data, limit)?;
-
-    while let Some(result) = body.frame().await {
-        let frame = result.map_err(|e| JsError::new((&e.to_string()).into()))?;
-        if let Some(chunk) = frame.data_ref() {
-            data.extend_from_slice(chunk);
-        }
-        check_limit(&data, limit)?;
-    }
-
-    Ok(data)
+    Ok(buf.freeze())
 }
 
 fn check_limit(buf: &[u8], limit: usize) -> Result<(), JsError> {
@@ -207,6 +210,12 @@ fn check_limit(buf: &[u8], limit: usize) -> Result<(), JsError> {
 
 #[derive(Debug)]
 pub struct JsError(String);
+
+impl From<RequestBodyError> for JsError {
+    fn from(value: RequestBodyError) -> Self {
+        JsError((value.to_string()).into())
+    }
+}
 
 impl JsError {
     fn new(raw: JsValue) -> Self {

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -58,7 +58,7 @@ impl Service<Request<RawRequestBody>> for RawClient {
     // The fetch API promises to call these futures sequentially
     #[allow(clippy::await_holding_refcell_ref)]
     async fn call(&self, req: Request<RawRequestBody>) -> Result<Self::Response, Self::Error> {
-        let (parts, body) = req.into_parts();
+        let (parts, mut body) = req.into_parts();
 
         let init = RequestInit::new();
         init.set_method(parts.method.as_str());

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -78,10 +78,10 @@ impl Service<Request<RawRequestBody>> for RawClient {
         // Firefox today. They are supported in Chrome (paired with 'duplex: half'). We'll just
         // buffer the body since it's compatible with every browser, and it's not simple to
         // determine at runtime which browser we're running in.
-        let data = read_body(body, MAX_BODY_SIZE).await?.to_vec();
-
-        let js_array = Uint8Array::from(&data[..]);
-        init.set_body(&js_array.into());
+        if let Some(data) = read_body(body, MAX_BODY_SIZE).await? {
+            let js_array = Uint8Array::from(&data[..]);
+            init.set_body(&js_array.into());
+        };
 
         let abort_controller = AbortController::new().map_err(JsError::new)?;
         init.set_signal(Some(&abort_controller.signal()));
@@ -173,12 +173,12 @@ impl Body for RawResponseBody {
     }
 }
 
-async fn read_body(body: RawRequestBody, limit: usize) -> Result<Bytes, JsError> {
+async fn read_body(body: RawRequestBody, limit: usize) -> Result<Option<Bytes>, JsError> {
     let mut data_stream = body.into_data_stream();
 
     let first = match data_stream.try_next().await? {
         Some(bytes) => bytes,
-        None => return Ok(Bytes::new()),
+        None => return Ok(None),
     };
     check_limit(&first, limit)?;
 
@@ -189,7 +189,7 @@ async fn read_body(body: RawRequestBody, limit: usize) -> Result<Bytes, JsError>
             buf.extend_from_slice(&first);
             buf.extend_from_slice(&second);
         }
-        None => return Ok(first),
+        None => return Ok(Some(first)),
     }
     check_limit(&first, limit)?;
 
@@ -198,7 +198,7 @@ async fn read_body(body: RawRequestBody, limit: usize) -> Result<Bytes, JsError>
         check_limit(&buf, limit)?;
     }
 
-    Ok(buf.freeze())
+    Ok(Some(buf.freeze()))
 }
 
 fn check_limit(buf: &[u8], limit: usize) -> Result<(), JsError> {

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -89,7 +89,11 @@ impl Service<Request<RawRequestBody>> for RawClient {
         let mut pull: Option<Closure<dyn FnMut(ReadableStreamDefaultController) -> Promise>> = None;
 
         if !body.is_end_stream() {
-            let should_buffer = body.size_hint().upper().map(|u| u <= FIFTY_MB).unwrap_or_default();
+            let should_buffer = body
+                .size_hint()
+                .upper()
+                .map(|u| u <= FIFTY_MB)
+                .unwrap_or_default();
             if should_buffer {
                 let mut data = Vec::new();
 
@@ -114,13 +118,15 @@ impl Service<Request<RawRequestBody>> for RawClient {
                                 match body.borrow_mut().frame().await {
                                     Some(Ok(frame)) => match frame.data_ref() {
                                         Some(data) => {
-                                            let chunk = Uint8Array::new_with_length(data.len() as u32);
+                                            let chunk =
+                                                Uint8Array::new_with_length(data.len() as u32);
                                             chunk.copy_from(data);
                                             controller.enqueue_with_chunk(&chunk.into())?;
                                             Ok(JsValue::UNDEFINED)
                                         }
                                         None => {
-                                            Err(js_sys::Error::new("unsupported trailers frame").into())
+                                            Err(js_sys::Error::new("unsupported trailers frame")
+                                                .into())
                                         }
                                     },
                                     None => {

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -61,6 +61,12 @@ impl Service<Request<RawRequestBody>> for RawClient {
 
         let init = RequestInit::new();
         init.set_method(parts.method.as_str());
+        js_sys::Reflect::set(
+            &init,
+            &JsValue::from_str("duplex"),
+            &JsValue::from_str("half"),
+        )
+        .map_err(JsError::new)?;
 
         let headers = Headers::new().map_err(JsError::new)?;
         for (mut name, value) in &parts.headers {

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -191,7 +191,7 @@ async fn read_body(body: RawRequestBody, limit: usize) -> Result<Option<Bytes>, 
         }
         None => return Ok(Some(first)),
     }
-    check_limit(&first, limit)?;
+    check_limit(&buf, limit)?;
 
     while let Some(bytes) = data_stream.try_next().await? {
         buf.extend_from_slice(&bytes);

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -34,6 +34,7 @@ use web_sys::{
     ReadableStreamDefaultReader, ReadableStreamReadResult, RequestInit, UnderlyingSource,
 };
 
+const FIFTY_MB: u64 = 50 * 1024 * 1024;
 static FETCH_USER_AGENT: HeaderName = HeaderName::from_static("fetch-user-agent");
 
 #[wasm_bindgen]
@@ -57,10 +58,13 @@ impl Service<Request<RawRequestBody>> for RawClient {
     // The fetch API promises to call these futures sequentially
     #[allow(clippy::await_holding_refcell_ref)]
     async fn call(&self, req: Request<RawRequestBody>) -> Result<Self::Response, Self::Error> {
-        let (parts, mut body) = req.into_parts();
+        let (parts, body) = req.into_parts();
 
         let init = RequestInit::new();
         init.set_method(parts.method.as_str());
+
+        // This isn't exposed on web_sys right now but it is required for ReadableStream bodies
+        // https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#duplex
         js_sys::Reflect::set(
             &init,
             &JsValue::from_str("duplex"),
@@ -85,17 +89,56 @@ impl Service<Request<RawRequestBody>> for RawClient {
         let mut pull: Option<Closure<dyn FnMut(ReadableStreamDefaultController) -> Promise>> = None;
 
         if !body.is_end_stream() {
-            let mut data = Vec::new();
+            let should_buffer = body.size_hint().upper().map(|u| u <= FIFTY_MB).unwrap_or_default();
+            if should_buffer {
+                let mut data = Vec::new();
 
-            while let Some(result) = body.frame().await {
-                let frame = result.map_err(|e| JsError::new((&e.to_string()).into()))?;
-                if let Some(chunk) = frame.data_ref() {
-                    data.extend_from_slice(chunk);
+                while let Some(result) = body.frame().await {
+                    let frame = result.map_err(|e| JsError::new((&e.to_string()).into()))?;
+                    if let Some(chunk) = frame.data_ref() {
+                        data.extend_from_slice(chunk);
+                    }
                 }
-            }
 
-            let js_array = Uint8Array::from(&data[..]);
-            init.set_body(&js_array.into());
+                let js_array = Uint8Array::from(&data[..]);
+                init.set_body(&js_array.into());
+            } else {
+                let underlying_source = UnderlyingSource::new();
+
+                let body = Rc::new(RefCell::new(body));
+                let pull = pull.insert(Closure::new(
+                    move |controller: ReadableStreamDefaultController| {
+                        wasm_bindgen_futures::future_to_promise({
+                            let body = body.clone();
+                            async move {
+                                match body.borrow_mut().frame().await {
+                                    Some(Ok(frame)) => match frame.data_ref() {
+                                        Some(data) => {
+                                            let chunk = Uint8Array::new_with_length(data.len() as u32);
+                                            chunk.copy_from(data);
+                                            controller.enqueue_with_chunk(&chunk.into())?;
+                                            Ok(JsValue::UNDEFINED)
+                                        }
+                                        None => {
+                                            Err(js_sys::Error::new("unsupported trailers frame").into())
+                                        }
+                                    },
+                                    None => {
+                                        controller.close()?;
+                                        Ok(JsValue::UNDEFINED)
+                                    }
+                                    Some(Err(e)) => Err(js_sys::Error::new(&e.to_string()).into()),
+                                }
+                            }
+                        })
+                    },
+                ));
+                underlying_source.set_pull(pull.as_ref().unchecked_ref());
+
+                let stream = ReadableStream::new_with_underlying_source(underlying_source.as_ref())
+                    .map_err(JsError::new)?;
+                init.set_body(stream.as_ref());
+            }
         }
 
         let abort_controller = AbortController::new().map_err(JsError::new)?;

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -182,7 +182,7 @@ async fn read_body(mut body: RawRequestBody, limit: usize) -> Result<Vec<u8>, Js
                 data.extend_from_slice(chunk);
             }
         }
-        None => return Ok(Vec::new()),
+        None => return Ok(data),
     }
 
     check_limit(&data, limit)?;

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -57,7 +57,7 @@ impl Service<Request<RawRequestBody>> for RawClient {
     // The fetch API promises to call these futures sequentially
     #[allow(clippy::await_holding_refcell_ref)]
     async fn call(&self, req: Request<RawRequestBody>) -> Result<Self::Response, Self::Error> {
-        let (parts, body) = req.into_parts();
+        let (parts, mut body) = req.into_parts();
 
         let init = RequestInit::new();
         init.set_method(parts.method.as_str());
@@ -85,41 +85,17 @@ impl Service<Request<RawRequestBody>> for RawClient {
         let mut pull: Option<Closure<dyn FnMut(ReadableStreamDefaultController) -> Promise>> = None;
 
         if !body.is_end_stream() {
-            let underlying_source = UnderlyingSource::new();
+            let mut data = Vec::new();
 
-            let body = Rc::new(RefCell::new(body));
-            let pull = pull.insert(Closure::new(
-                move |controller: ReadableStreamDefaultController| {
-                    wasm_bindgen_futures::future_to_promise({
-                        let body = body.clone();
-                        async move {
-                            match body.borrow_mut().frame().await {
-                                Some(Ok(frame)) => match frame.data_ref() {
-                                    Some(data) => {
-                                        let chunk = Uint8Array::new_with_length(data.len() as u32);
-                                        chunk.copy_from(data);
-                                        controller.enqueue_with_chunk(&chunk.into())?;
-                                        Ok(JsValue::UNDEFINED)
-                                    }
-                                    None => {
-                                        Err(js_sys::Error::new("unsupported trailers frame").into())
-                                    }
-                                },
-                                None => {
-                                    controller.close()?;
-                                    Ok(JsValue::UNDEFINED)
-                                }
-                                Some(Err(e)) => Err(js_sys::Error::new(&e.to_string()).into()),
-                            }
-                        }
-                    })
-                },
-            ));
-            underlying_source.set_pull(pull.as_ref().unchecked_ref());
+            while let Some(result) = body.frame().await {
+                let frame = result.map_err(|e| JsError::new((&e.to_string()).into()))?;
+                if let Some(chunk) = frame.data_ref() {
+                    data.extend_from_slice(chunk);
+                }
+            }
 
-            let stream = ReadableStream::new_with_underlying_source(underlying_source.as_ref())
-                .map_err(JsError::new)?;
-            init.set_body(stream.as_ref());
+            let js_array = Uint8Array::from(&data[..]);
+            init.set_body(&js_array.into());
         }
 
         let abort_controller = AbortController::new().map_err(JsError::new)?;

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -78,7 +78,7 @@ impl Service<Request<RawRequestBody>> for RawClient {
         // Firefox today. They are supported in Chrome (paired with 'duplex: half'). We'll just
         // buffer the body since it's compatible with every browser, and it's not simple to
         // determine at runtime which browser we're running in.
-        let data = read_body(body, MAX_BODY_SIZE).await?;
+        let data = read_body(body, MAX_BODY_SIZE).await?.to_vec();
 
         let js_array = Uint8Array::from(&data[..]);
         init.set_body(&js_array.into());

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -28,8 +28,7 @@ use std::{error, fmt};
 use wasm_bindgen::prelude::{wasm_bindgen, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
-    AbortController, Headers, ReadableStreamDefaultReader,
-    ReadableStreamReadResult, RequestInit,
+    AbortController, Headers, ReadableStreamDefaultReader, ReadableStreamReadResult, RequestInit,
 };
 
 const MAX_BODY_SIZE: usize = 50 * 1024 * 1024;

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -213,7 +213,7 @@ pub struct JsError(String);
 
 impl From<RequestBodyError> for JsError {
     fn from(value: RequestBodyError) -> Self {
-        JsError((value.to_string()).into())
+        JsError(value.to_string())
     }
 }
 

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -20,21 +20,19 @@ use http::{header, HeaderName, HeaderValue, Request, Response, StatusCode};
 use http_body::{Body, Frame};
 use http_body_util::BodyExt;
 use js_sys::{Array, JsString, Promise, Uint8Array};
-use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::future::Future;
 use std::pin::Pin;
-use std::rc::Rc;
 use std::task::{ready, Context, Poll};
 use std::{error, fmt};
 use wasm_bindgen::prelude::{wasm_bindgen, Closure, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
-    AbortController, Headers, ReadableStream, ReadableStreamDefaultController,
-    ReadableStreamDefaultReader, ReadableStreamReadResult, RequestInit, UnderlyingSource,
+    AbortController, Headers, ReadableStreamDefaultController, ReadableStreamDefaultReader,
+    ReadableStreamReadResult, RequestInit,
 };
 
-const FIFTY_MB: u64 = 50 * 1024 * 1024;
+const FIFTY_MB: usize = 50 * 1024 * 1024;
 static FETCH_USER_AGENT: HeaderName = HeaderName::from_static("fetch-user-agent");
 
 #[wasm_bindgen]
@@ -63,15 +61,6 @@ impl Service<Request<RawRequestBody>> for RawClient {
         let init = RequestInit::new();
         init.set_method(parts.method.as_str());
 
-        // This isn't exposed on web_sys right now but it is required for ReadableStream bodies
-        // https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#duplex
-        js_sys::Reflect::set(
-            &init,
-            &JsValue::from_str("duplex"),
-            &JsValue::from_str("half"),
-        )
-        .map_err(JsError::new)?;
-
         let headers = Headers::new().map_err(JsError::new)?;
         for (mut name, value) in &parts.headers {
             if name == header::USER_AGENT {
@@ -85,67 +74,20 @@ impl Service<Request<RawRequestBody>> for RawClient {
 
         init.set_headers(headers.as_ref());
 
-        // We need to keep the closure alive until we finish processing the request
-        let mut pull: Option<Closure<dyn FnMut(ReadableStreamDefaultController) -> Promise>> = None;
-
-        if !body.is_end_stream() {
-            let should_buffer = body
-                .size_hint()
-                .upper()
-                .map(|u| u <= FIFTY_MB)
-                .unwrap_or_default();
-            if should_buffer {
-                let mut data = Vec::new();
-
-                while let Some(result) = body.frame().await {
-                    let frame = result.map_err(|e| JsError::new((&e.to_string()).into()))?;
-                    if let Some(chunk) = frame.data_ref() {
-                        data.extend_from_slice(chunk);
-                    }
-                }
-
-                let js_array = Uint8Array::from(&data[..]);
-                init.set_body(&js_array.into());
-            } else {
-                let underlying_source = UnderlyingSource::new();
-
-                let body = Rc::new(RefCell::new(body));
-                let pull = pull.insert(Closure::new(
-                    move |controller: ReadableStreamDefaultController| {
-                        wasm_bindgen_futures::future_to_promise({
-                            let body = body.clone();
-                            async move {
-                                match body.borrow_mut().frame().await {
-                                    Some(Ok(frame)) => match frame.data_ref() {
-                                        Some(data) => {
-                                            let chunk =
-                                                Uint8Array::new_with_length(data.len() as u32);
-                                            chunk.copy_from(data);
-                                            controller.enqueue_with_chunk(&chunk.into())?;
-                                            Ok(JsValue::UNDEFINED)
-                                        }
-                                        None => {
-                                            Err(js_sys::Error::new("unsupported trailers frame")
-                                                .into())
-                                        }
-                                    },
-                                    None => {
-                                        controller.close()?;
-                                        Ok(JsValue::UNDEFINED)
-                                    }
-                                    Some(Err(e)) => Err(js_sys::Error::new(&e.to_string()).into()),
-                                }
-                            }
-                        })
-                    },
-                ));
-                underlying_source.set_pull(pull.as_ref().unchecked_ref());
-
-                let stream = ReadableStream::new_with_underlying_source(underlying_source.as_ref())
-                    .map_err(JsError::new)?;
-                init.set_body(stream.as_ref());
+        let mut data = Vec::new();
+        while let Some(result) = body.frame().await {
+            let frame = result.map_err(|e| JsError::new((&e.to_string()).into()))?;
+            if let Some(chunk) = frame.data_ref() {
+                data.extend_from_slice(chunk);
             }
+            check_limit(&data, FIFTY_MB)?;
         }
+
+        let js_array = Uint8Array::from(&data[..]);
+        init.set_body(&js_array.into());
+
+        // We need to keep the closure alive until we finish processing the request
+        let pull: Option<Closure<dyn FnMut(ReadableStreamDefaultController) -> Promise>> = None;
 
         let abort_controller = AbortController::new().map_err(JsError::new)?;
         init.set_signal(Some(&abort_controller.signal()));
@@ -237,6 +179,13 @@ impl Body for RawResponseBody {
 
         Poll::Ready(Some(Ok(Frame::data(Bytes::from(chunk.to_vec())))))
     }
+}
+
+fn check_limit(buf: &[u8], limit: usize) -> Result<(), JsError> {
+    if buf.len() > limit {
+        return Err(JsError::new(JsString::from("body too large").into()));
+    }
+    Ok(())
 }
 
 #[derive(Debug)]

--- a/conjure-runtime/src/service/raw/js.rs
+++ b/conjure-runtime/src/service/raw/js.rs
@@ -25,14 +25,14 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
 use std::{error, fmt};
-use wasm_bindgen::prelude::{wasm_bindgen, Closure, JsCast, JsValue};
+use wasm_bindgen::prelude::{wasm_bindgen, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
-    AbortController, Headers, ReadableStreamDefaultController, ReadableStreamDefaultReader,
+    AbortController, Headers, ReadableStreamDefaultReader,
     ReadableStreamReadResult, RequestInit,
 };
 
-const FIFTY_MB: usize = 50 * 1024 * 1024;
+const MAX_BODY_SIZE: usize = 50 * 1024 * 1024;
 static FETCH_USER_AGENT: HeaderName = HeaderName::from_static("fetch-user-agent");
 
 #[wasm_bindgen]
@@ -56,7 +56,7 @@ impl Service<Request<RawRequestBody>> for RawClient {
     // The fetch API promises to call these futures sequentially
     #[allow(clippy::await_holding_refcell_ref)]
     async fn call(&self, req: Request<RawRequestBody>) -> Result<Self::Response, Self::Error> {
-        let (parts, mut body) = req.into_parts();
+        let (parts, body) = req.into_parts();
 
         let init = RequestInit::new();
         init.set_method(parts.method.as_str());
@@ -74,20 +74,14 @@ impl Service<Request<RawRequestBody>> for RawClient {
 
         init.set_headers(headers.as_ref());
 
-        let mut data = Vec::new();
-        while let Some(result) = body.frame().await {
-            let frame = result.map_err(|e| JsError::new((&e.to_string()).into()))?;
-            if let Some(chunk) = frame.data_ref() {
-                data.extend_from_slice(chunk);
-            }
-            check_limit(&data, FIFTY_MB)?;
-        }
+        // We're buffering the entire body because ReadableStreams are not supported in Safari and
+        // Firefox today. They are supported in Chrome (paired with 'duplex: half'). We'll just
+        // buffer the body since it's compatible with every browser, and it's not simple to
+        // determine at runtime which browser we're running in.
+        let data = read_body(body, MAX_BODY_SIZE).await?;
 
         let js_array = Uint8Array::from(&data[..]);
         init.set_body(&js_array.into());
-
-        // We need to keep the closure alive until we finish processing the request
-        let pull: Option<Closure<dyn FnMut(ReadableStreamDefaultController) -> Promise>> = None;
 
         let abort_controller = AbortController::new().map_err(JsError::new)?;
         init.set_signal(Some(&abort_controller.signal()));
@@ -109,7 +103,6 @@ impl Service<Request<RawRequestBody>> for RawClient {
             }),
             pending: None,
             _guard: guard,
-            _pull: pull,
         };
         let mut resp = Response::new(body);
 
@@ -145,7 +138,6 @@ pub struct RawResponseBody {
     reader: Option<ReadableStreamDefaultReader>,
     pending: Option<JsFuture>,
     _guard: AbortGuard,
-    _pull: Option<Closure<dyn FnMut(ReadableStreamDefaultController) -> Promise>>,
 }
 
 impl Body for RawResponseBody {
@@ -179,6 +171,32 @@ impl Body for RawResponseBody {
 
         Poll::Ready(Some(Ok(Frame::data(Bytes::from(chunk.to_vec())))))
     }
+}
+
+async fn read_body(mut body: RawRequestBody, limit: usize) -> Result<Vec<u8>, JsError> {
+    let mut data = Vec::new();
+
+    match body.frame().await {
+        Some(result) => {
+            let frame = result.map_err(|e| JsError::new((&e.to_string()).into()))?;
+            if let Some(chunk) = frame.data_ref() {
+                data.extend_from_slice(chunk);
+            }
+        }
+        None => return Ok(Vec::new()),
+    }
+
+    check_limit(&data, limit)?;
+
+    while let Some(result) = body.frame().await {
+        let frame = result.map_err(|e| JsError::new((&e.to_string()).into()))?;
+        if let Some(chunk) = frame.data_ref() {
+            data.extend_from_slice(chunk);
+        }
+        check_limit(&data, limit)?;
+    }
+
+    Ok(data)
 }
 
 fn check_limit(buf: &[u8], limit: usize) -> Result<(), JsError> {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Clients were broken in all browsers. Because we're using fetch with readable stream bodies we need to set `duplex: "half"` to get support. This patch also only works in chrome, but, readable stream bodies like this are currently not supported in other non-chromium browsers (safari, firefox, etc). This is not a long term solution, this just makes it work in chrome, and we maybe should not even merge this.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
add duplex half to get fetch working in chrome browsers
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

