### PR TITLE
Add the ability to override the conjure runtime

### DIFF
--- a/conjure-runtime/src/blocking/body.rs
+++ b/conjure-runtime/src/blocking/body.rs
@@ -130,7 +130,7 @@ impl BodyWriter {
 
     fn send(&mut self, message: BodyPart) -> io::Result<()> {
         executor::block_on(self.sender.send(message))
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     }
 
     /// Writes a block of body bytes.

--- a/conjure-runtime/src/blocking/body.rs
+++ b/conjure-runtime/src/blocking/body.rs
@@ -129,8 +129,7 @@ impl BodyWriter {
     }
 
     fn send(&mut self, message: BodyPart) -> io::Result<()> {
-        executor::block_on(self.sender.send(message))
-            .map_err(io::Error::other)
+        executor::block_on(self.sender.send(message)).map_err(io::Error::other)
     }
 
     /// Writes a block of body bytes.

--- a/conjure-runtime/src/body.rs
+++ b/conjure-runtime/src/body.rs
@@ -51,7 +51,7 @@ impl BodyWriter {
             .sender
             .send(RequestBodyPart::Done)
             .await
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
         Ok(())
     }
 
@@ -65,7 +65,7 @@ impl BodyWriter {
             .sender
             .send(RequestBodyPart::Frame(Frame::data(bytes)))
             .await
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
         Ok(())
     }
 }
@@ -91,11 +91,11 @@ impl AsyncWrite for BodyWriter {
             return Poll::Ready(Ok(()));
         }
 
-        ready!(this.sender.poll_ready(cx)).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        ready!(this.sender.poll_ready(cx)).map_err(io::Error::other)?;
         let chunk = this.buf.split().freeze();
         this.sender
             .start_send(RequestBodyPart::Frame(Frame::data(chunk)))
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
 
         Poll::Ready(Ok(()))
     }
@@ -177,7 +177,7 @@ impl AsyncBufRead for ResponseBody {
         while !self.cur.has_remaining() {
             match ready!(self.as_mut().project().body.poll_frame(cx))
                 .transpose()
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+                .map_err(io::Error::other)?
             {
                 Some(frame) => {
                     if let Ok(data) = frame.into_data() {

--- a/conjure-runtime/src/builder.rs
+++ b/conjure-runtime/src/builder.rs
@@ -446,6 +446,20 @@ impl Builder<Complete> {
         self.0.uncached.host_metrics.as_ref()
     }
 
+    /// Sets the Conjure runtime used to configure request and response encodings.
+    ///
+    /// Defaults to `ConjureRuntime::default()`.
+    #[inline]
+    pub fn conjure_runtime(mut self, conjure_runtime: Arc<ConjureRuntime>) -> Self {
+        self.0.uncached.conjure_runtime = conjure_runtime;
+        self
+    }
+
+    /// Returns the configured Conjure runtime.
+    pub fn get_conjure_runtime(&self) -> &Arc<ConjureRuntime> {
+        &self.0.uncached.conjure_runtime
+    }
+
     /// Overrides the `hostIndex` field included in metrics.
     #[inline]
     pub fn override_host_index(mut self, override_host_index: usize) -> Self {

--- a/conjure-runtime/src/client_factory.rs
+++ b/conjure-runtime/src/client_factory.rs
@@ -532,7 +532,8 @@ impl StateBuilder {
             .server_qos(self.server_qos)
             .service_error(self.service_error)
             .idempotency(self.idempotency)
-            .node_selection_strategy(self.node_selection_strategy);
+            .node_selection_strategy(self.node_selection_strategy)
+            .conjure_runtime(self.cache_manager.uncached().conjure_runtime.clone());
 
         if let Some(metrics) = self.cache_manager.uncached().metrics.clone() {
             builder = builder.metrics(metrics);

--- a/conjure-runtime/src/client_factory.rs
+++ b/conjure-runtime/src/client_factory.rs
@@ -257,6 +257,20 @@ impl ClientFactory {
         self.0.cache_manager.uncached().host_metrics.as_ref()
     }
 
+    /// Sets the Conjure runtime used to configure request and response encodings.
+    ///
+    /// Defaults to `ConjureRuntime::default()`.
+    #[inline]
+    pub fn conjure_runtime(mut self, conjure_runtime: Arc<ConjureRuntime>) -> Self {
+        self.0.cache_manager.uncached_mut().conjure_runtime = conjure_runtime;
+        self
+    }
+
+    /// Returns the configured Conjure runtime.
+    pub fn get_conjure_runtime(&self) -> &Arc<ConjureRuntime> {
+        &self.0.cache_manager.uncached().conjure_runtime
+    }
+
     fn state_builder(&self, service: &str) -> StateBuilder {
         StateBuilder {
             service: service.to_string(),

--- a/conjure-runtime/src/user_agent.rs
+++ b/conjure-runtime/src/user_agent.rs
@@ -36,11 +36,11 @@ impl fmt::Display for UserAgent {
         write!(fmt, "{}", self.primary)?;
 
         if let Some(ref node_id) = self.node_id {
-            write!(fmt, " (nodeId:{})", node_id)?;
+            write!(fmt, " (nodeId:{node_id})")?;
         }
 
         for agent in &self.informational {
-            write!(fmt, " {}", agent)?;
+            write!(fmt, " {agent}")?;
         }
 
         Ok(())

--- a/conjure-verification-api/build.rs
+++ b/conjure-verification-api/build.rs
@@ -29,11 +29,7 @@ fn main() {
 
 fn download(name: &str, classifier: &str, extension: &str) -> Vec<u8> {
     let url = format!(
-        "https://repo1.maven.org/maven2/com/palantir/conjure/verification/{name}/{version}/{name}-{version}{classifier}.{extension}",
-        name = name,
-        version = VERSION,
-        classifier = classifier,
-        extension = extension,
+        "https://repo1.maven.org/maven2/com/palantir/conjure/verification/{name}/{VERSION}/{name}-{VERSION}{classifier}.{extension}",
     );
 
     let resp = attohttpc::get(&url).send().unwrap();

--- a/conjure-verification/build.rs
+++ b/conjure-verification/build.rs
@@ -268,8 +268,8 @@ fn generate_single_tests(
 ) {
     let empty_ignored = BTreeSet::new();
 
-    let blocking_client = Ident::new(&format!("{}Client", service), Span::call_site());
-    let async_client = Ident::new(&format!("Async{}Client", service), Span::call_site());
+    let blocking_client = Ident::new(&format!("{service}Client"), Span::call_site());
+    let async_client = Ident::new(&format!("Async{service}Client"), Span::call_site());
 
     for (name, cases) in tests {
         let ignored_cases = ignored_tests.get(name).unwrap_or(&empty_ignored);

--- a/conjure-verification/src/lib.rs
+++ b/conjure-verification/src/lib.rs
@@ -38,7 +38,7 @@ fn main() {
     test_blocking(builder.build_blocking().unwrap(), &mut passed, &mut failed);
     test_async(builder.build().unwrap(), &mut passed, &mut failed);
 
-    println!("{} passed, {} failed", passed, failed);
+    println!("{passed} passed, {failed} failed");
 
     if failed != 0 {
         process::exit(1);


### PR DESCRIPTION
## Before this PR
Clients created via the builder or client factory always used a default runtime.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added the ability to override the conjure runtime used by the builder and client factory.
==COMMIT_MSG==