### PR TITLE
Add pinned-certs option for leaf certificate pinning

### DIFF
--- a/conjure-runtime-config/src/lib.rs
+++ b/conjure-runtime-config/src/lib.rs
@@ -220,6 +220,9 @@ pub struct SecurityConfig {
     key_file: Option<PathBuf>,
     #[builder(default, into)]
     cert_file: Option<PathBuf>,
+    #[serde(default)]
+    #[builder(list(item(type = String, into)))]
+    pinned_certs: Vec<String>,
 }
 
 impl SecurityConfig {
@@ -243,6 +246,22 @@ impl SecurityConfig {
     /// the remainder of the certificate chain to a trusted root.
     pub fn cert_file(&self) -> Option<&Path> {
         self.cert_file.as_deref()
+    }
+
+    /// PEM-formatted leaf certificates to pin against, one PEM document per entry.
+    ///
+    /// When non-empty, the client will only consider a TLS connection valid if the server's end-entity certificate
+    /// matches one of the certificates in this list. The certificate chain itself is *not* validated against any
+    /// trust anchor; pinning the leaf is sufficient to identify the server. This is intended as an escape hatch for
+    /// environments whose CA hierarchy uses X.509 features (e.g. `directoryName` name constraints, see
+    /// [RFC 5280 §4.2.1.10](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10)) that the underlying
+    /// TLS library does not support.
+    ///
+    /// Because the chain is skipped, the configured certificates must be rotated in lockstep with the server's leaf
+    /// certificate. Operators that enable this option should ensure they have a process to keep the pins up to date,
+    /// or service traffic will fail when the server's certificate is renewed.
+    pub fn pinned_certs(&self) -> &[String] {
+        &self.pinned_certs
     }
 }
 

--- a/conjure-runtime-config/src/test.rs
+++ b/conjure-runtime-config/src/test.rs
@@ -88,6 +88,38 @@ fn root_defaults() {
 }
 
 #[test]
+fn pinned_certs() {
+    let config = r#"
+        {
+            "services": {
+                "foo": {
+                    "uris": [
+                        "https://foo1.com"
+                    ],
+                    "security": {
+                        "pinned-certs": [
+                            "-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n",
+                            "-----BEGIN CERTIFICATE-----\nBBBB\n-----END CERTIFICATE-----\n"
+                        ]
+                    }
+                }
+            }
+        }
+    "#;
+    let config = serde_json::from_str::<ServicesConfig>(config).unwrap();
+    let expected = ServiceConfig::builder()
+        .uris(vec!["https://foo1.com".parse().unwrap()])
+        .security(
+            SecurityConfig::builder()
+                .push_pinned_certs("-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n")
+                .push_pinned_certs("-----BEGIN CERTIFICATE-----\nBBBB\n-----END CERTIFICATE-----\n")
+                .build(),
+        )
+        .build();
+    assert_eq!(config.merged_service("foo"), Some(expected));
+}
+
+#[test]
 fn service_overrides() {
     let config = r#"
         {

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -102,6 +102,7 @@ hyper-rustls = { version = "0.27", default-features = false, features = [
 openssl = "0.10.50"
 serde_yaml = "0.9"
 tokio-openssl = "0.6"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 tokio-test = "0.4"
 tokio = { version = "1.0", features = ["full"] }
 tower-util = "0.3"

--- a/conjure-runtime/Cargo.toml
+++ b/conjure-runtime/Cargo.toml
@@ -65,6 +65,7 @@ rustls = { version = "0.23", default-features = false, features = [
     "std",
     "tls12",
 ] }
+subtle = "2"
 tokio-io-timeout = "1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread", "time"] }
 tower-layer = "0.3"

--- a/conjure-runtime/src/service/raw/hyper.rs
+++ b/conjure-runtime/src/service/raw/hyper.rs
@@ -41,6 +41,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
+use subtle::{Choice, ConstantTimeEq};
 use tower_layer::Layer;
 use webpki_roots::TLS_SERVER_ROOTS;
 
@@ -217,11 +218,11 @@ impl ServerCertVerifier for PinnedLeafVerifier {
         _ocsp_response: &[u8],
         _now: UnixTime,
     ) -> Result<ServerCertVerified, rustls::Error> {
-        if self
-            .pinned
-            .iter()
-            .any(|pin| pin.as_ref() == end_entity.as_ref())
-        {
+        let mut matched = Choice::from(0);
+        for pin in &self.pinned {
+            matched |= pin.as_ref().ct_eq(end_entity.as_ref());
+        }
+        if bool::from(matched) {
             Ok(ServerCertVerified::assertion())
         } else {
             Err(rustls::Error::InvalidCertificate(

--- a/conjure-runtime/src/service/raw/hyper.rs
+++ b/conjure-runtime/src/service/raw/hyper.rs
@@ -28,9 +28,10 @@ use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::{self, Client};
 use hyper_util::rt::{TokioExecutor, TokioTimer};
 use pin_project::pin_project;
-use rustls::crypto::ring;
-use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::{ClientConfig, RootCertStore};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::{self, ring, CryptoProvider};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
+use rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme};
 use rustls_pemfile::Item;
 use std::fs::File;
 use std::io::BufReader;
@@ -64,17 +65,42 @@ impl RawClient {
         let connector = TimeoutLayer::new(builder).layer(connector);
         let connector = ProxyConnectorLayer::new(builder)?.layer(connector);
 
-        let mut roots = RootCertStore::empty();
-        roots.extend(TLS_SERVER_ROOTS.iter().cloned());
+        let provider = Arc::new(ring::default_provider());
 
-        if let Some(ca_file) = builder.get_security().ca_file() {
-            let certs = load_certs_file(ca_file)?;
-            roots.add_parsable_certificates(certs);
-        }
-        let client_config = ClientConfig::builder_with_provider(Arc::new(ring::default_provider()))
+        let builder_stage = ClientConfig::builder_with_provider(provider.clone())
             .with_safe_default_protocol_versions()
-            .map_err(Error::internal_safe)?
-            .with_root_certificates(roots);
+            .map_err(Error::internal_safe)?;
+
+        let unauthed_config = if builder.get_security().pinned_certs().is_empty() {
+            let mut roots = RootCertStore::empty();
+            roots.extend(TLS_SERVER_ROOTS.iter().cloned());
+
+            if let Some(ca_file) = builder.get_security().ca_file() {
+                let certs = load_certs_file(ca_file)?;
+                roots.add_parsable_certificates(certs);
+            }
+            builder_stage.with_root_certificates(roots)
+        } else {
+            let mut pinned = Vec::with_capacity(builder.get_security().pinned_certs().len());
+            for (idx, pem) in builder.get_security().pinned_certs().iter().enumerate() {
+                let mut reader = BufReader::new(pem.as_bytes());
+                let mut certs = rustls_pemfile::certs(&mut reader)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(Error::internal_safe)?;
+                if certs.len() != 1 {
+                    return Err(Error::internal_safe(
+                        "pinned-certs entry must contain exactly one PEM-encoded certificate",
+                    )
+                    .with_safe_param("index", idx)
+                    .with_safe_param("count", certs.len()));
+                }
+                pinned.push(certs.pop().unwrap());
+            }
+            let verifier = Arc::new(PinnedLeafVerifier::new(pinned, provider.clone()));
+            builder_stage
+                .dangerous()
+                .with_custom_certificate_verifier(verifier)
+        };
 
         let client_config = match (
             builder.get_security().cert_file(),
@@ -84,11 +110,11 @@ impl RawClient {
                 let cert_chain = load_certs_file(cert_file)?;
                 let private_key = load_private_key(key_file)?;
 
-                client_config
+                unauthed_config
                     .with_client_auth_cert(cert_chain, private_key)
                     .map_err(Error::internal_safe)?
             }
-            (None, None) => client_config.with_no_client_auth(),
+            (None, None) => unauthed_config.with_no_client_auth(),
             _ => {
                 return Err(Error::internal_safe(
                     "neither or both of key-file and cert-file must be set in the client \
@@ -157,6 +183,85 @@ fn load_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, Error> {
         _ => Err(Error::internal_safe(
             "expected a PKCS#1, PKCS#8, or Sec1 private key",
         )),
+    }
+}
+
+/// A `ServerCertVerifier` that accepts a connection iff the server's end-entity certificate exactly
+/// matches one of a configured set of pinned leaf certificates.
+///
+/// The certificate chain is *not* validated. Pinning the leaf is sufficient to identify the server,
+/// since rustls separately verifies the handshake signature against the leaf's public key (see
+/// `verify_tls12_signature` / `verify_tls13_signature`), which proves the server holds the matching
+/// private key.
+///
+/// This is intended as an escape hatch for environments whose CA hierarchy uses X.509 features
+/// the underlying TLS library does not support (e.g. `directoryName` name constraints).
+#[derive(Debug)]
+struct PinnedLeafVerifier {
+    pinned: Vec<CertificateDer<'static>>,
+    provider: Arc<CryptoProvider>,
+}
+
+impl PinnedLeafVerifier {
+    fn new(pinned: Vec<CertificateDer<'static>>, provider: Arc<CryptoProvider>) -> Self {
+        PinnedLeafVerifier { pinned, provider }
+    }
+}
+
+impl ServerCertVerifier for PinnedLeafVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        if self
+            .pinned
+            .iter()
+            .any(|pin| pin.as_ref() == end_entity.as_ref())
+        {
+            Ok(ServerCertVerified::assertion())
+        } else {
+            Err(rustls::Error::InvalidCertificate(
+                rustls::CertificateError::UnknownIssuer,
+            ))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
     }
 }
 

--- a/conjure-runtime/src/test.rs
+++ b/conjure-runtime/src/test.rs
@@ -806,3 +806,187 @@ async fn fixed_body_has_content_length() {
     )
     .await
 }
+
+fn cert_file_pem() -> String {
+    std::fs::read_to_string(cert_file()).unwrap()
+}
+
+fn alt_self_signed_cert_pem() -> String {
+    use openssl::asn1::Asn1Time;
+    use openssl::hash::MessageDigest;
+    use openssl::pkey::PKey;
+    use openssl::rsa::Rsa;
+    use openssl::x509::{X509Builder, X509NameBuilder};
+
+    let rsa = Rsa::generate(2048).unwrap();
+    let pkey = PKey::from_rsa(rsa).unwrap();
+
+    let mut name = X509NameBuilder::new().unwrap();
+    name.append_entry_by_text("CN", "wrong.example.com")
+        .unwrap();
+    let name = name.build();
+
+    let mut builder = X509Builder::new().unwrap();
+    builder.set_version(2).unwrap();
+    builder.set_subject_name(&name).unwrap();
+    builder.set_issuer_name(&name).unwrap();
+    builder.set_pubkey(&pkey).unwrap();
+    builder
+        .set_not_before(&Asn1Time::days_from_now(0).unwrap())
+        .unwrap();
+    builder
+        .set_not_after(&Asn1Time::days_from_now(365).unwrap())
+        .unwrap();
+    builder.sign(&pkey, MessageDigest::sha256()).unwrap();
+    let cert = builder.build();
+    String::from_utf8(cert.to_pem().unwrap()).unwrap()
+}
+
+fn pinned_config_for(port: u16, pem: &str) -> ServiceConfig {
+    ServiceConfig::builder()
+        .uris(vec![format!("https://localhost:{port}").parse().unwrap()])
+        .security(
+            conjure_runtime_config::SecurityConfig::builder()
+                .push_pinned_certs(pem)
+                .build(),
+        )
+        .max_num_retries(0)
+        .build()
+}
+
+async fn pinned_client<F>(port: u16, pem: &str, check: impl FnOnce(Builder) -> F)
+where
+    F: Future<Output = ()>,
+{
+    let builder = Client::builder()
+        .service("service")
+        .user_agent(UserAgent::new(Agent::new("test", "1.0")))
+        .from_config(&pinned_config_for(port, pem));
+    check(builder).await
+}
+
+#[tokio::test]
+async fn pinned_certs_accepts_matching_leaf() {
+    // Notably, this config does *not* set `ca-file`, so the server's self-signed certificate is
+    // not in the trust store. The pin alone is what permits the connection.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let pem = cert_file_pem();
+
+    let server = server(listener, 1, |_| async move {
+        Ok(Response::new(Empty::new().boxed()))
+    });
+
+    let client = pinned_client(port, &pem, |builder| async move {
+        let response = builder
+            .build()
+            .unwrap()
+            .send(req().body(AsyncRequestBody::Empty).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    });
+
+    join!(server, client);
+}
+
+#[tokio::test]
+async fn pinned_certs_rejects_wrong_leaf() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let wrong_pem = alt_self_signed_cert_pem();
+
+    let server = async move {
+        // We expect the client to fail the TLS handshake. We still want a listener up so the
+        // failure is the cert pin mismatch and not a connection-refused.
+        let _ = listener.accept().await;
+    };
+
+    let client = pinned_client(port, &wrong_pem, |builder| async move {
+        let err = builder
+            .build()
+            .unwrap()
+            .send(req().body(AsyncRequestBody::Empty).unwrap())
+            .await
+            .err()
+            .expect("expected pinned-leaf mismatch to fail the request");
+        // The error should be a transport-layer error, not a remote (status code) error.
+        assert!(err.cause().downcast_ref::<RemoteError>().is_none());
+    });
+
+    join!(server, client);
+}
+
+#[tokio::test]
+async fn pinned_certs_rejects_correct_cert_with_wrong_key() {
+    // Defense-in-depth: pinning the leaf is only safe if the server actually proves it holds the
+    // matching private key. This test verifies that a server presenting the pinned cert but
+    // signing the TLS handshake with an unrelated key is rejected, even though the pin check
+    // (byte-comparison of the leaf) passes.
+    use openssl::pkey::PKey;
+    use openssl::rsa::Rsa;
+    use rustls::crypto::ring::sign::any_supported_type;
+    use rustls::pki_types::pem::PemObject;
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+    use rustls::server::{ClientHello, ResolvesServerCert, ServerConfig};
+    use rustls::sign::CertifiedKey;
+    use std::fmt;
+    use std::sync::Arc;
+    use tokio_rustls::TlsAcceptor;
+
+    let pem = cert_file_pem();
+    let cert_der = CertificateDer::from_pem_slice(pem.as_bytes()).unwrap();
+
+    // Fresh, unrelated keypair.
+    let rsa = Rsa::generate(2048).unwrap();
+    let pkey = PKey::from_rsa(rsa).unwrap();
+    let wrong_key_pem = pkey.private_key_to_pem_pkcs8().unwrap();
+    let wrong_key_der = PrivatePkcs8KeyDer::from_pem_slice(&wrong_key_pem).unwrap();
+    let signing_key = any_supported_type(&PrivateKeyDer::Pkcs8(wrong_key_der)).unwrap();
+
+    let certified = Arc::new(CertifiedKey::new(vec![cert_der], signing_key));
+
+    struct LyingResolver(Arc<CertifiedKey>);
+    impl fmt::Debug for LyingResolver {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("LyingResolver").finish()
+        }
+    }
+    impl ResolvesServerCert for LyingResolver {
+        fn resolve(&self, _: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+            Some(self.0.clone())
+        }
+    }
+
+    let server_config =
+        ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_no_client_auth()
+            .with_cert_resolver(Arc::new(LyingResolver(certified)));
+    let acceptor: TlsAcceptor = Arc::new(server_config).into();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let server = async move {
+        if let Ok((tcp, _)) = listener.accept().await {
+            // The handshake is expected to fail when rustls verifies the signature against the
+            // (mismatched) public key in the presented leaf.
+            let _ = acceptor.accept(tcp).await;
+        }
+    };
+
+    let client = pinned_client(port, &pem, |builder| async move {
+        let err = builder
+            .build()
+            .unwrap()
+            .send(req().body(AsyncRequestBody::Empty).unwrap())
+            .await
+            .err()
+            .expect("expected handshake signature failure");
+        assert!(err.cause().downcast_ref::<RemoteError>().is_none());
+    });
+
+    join!(server, client);
+}


### PR DESCRIPTION
Adds an opt-in `pinned-certs` field to SecurityConfig that swaps the default rustls/webpki chain verifier for a custom verifier matching the server's end-entity certificate byte-for-byte against a configured PEM file.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add pinned-cert-file option for leaf certificate pinning
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

